### PR TITLE
fix: change Links to anchors for contact page 🐛

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -75,7 +75,7 @@ module.exports = {
         // should be an object or a function that is executed in the browser
         //
         // Defaults to null
-        // defaultDataLayer: { platform: `gatsby` },
+        defaultDataLayer: { platform: `gatsby` },
 
         // Specify optional GTM environment details.
         // gtmAuth: `YOUR_GOOGLE_TAGMANAGER_ENVIRONMENT_AUTH_STRING`,

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -19,7 +19,7 @@ const Footer = () => {
     <footer className={styles.footer}>
       <h2>Get in touch.</h2>
       <p>
-        Have something to say? <Link to='/contact'>Hit me up</Link>.
+        Have something to say? <a href='/contact'>Hit me up</a>.
       </p>
       <div className={styles.iconBucket}>
         <h2>\\\\\</h2>

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -45,12 +45,12 @@ const Header = () => {
             </Link>
           </li>
           <li>
-            <Link
+            <a
               className={styles.navItem}
               activeClassName={styles.activeNavItem}
-              to='/contact'>
+              href='/contact'>
               Contact
-            </Link>
+            </a>
           </li>
         </ul>
       </nav>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -24,9 +24,9 @@ const Index = () => {
           <Link className={styles.headerButtonLink} to='/blog'>
             <button className={styles.headerButtonLight}>Blog</button>
           </Link>
-          <Link className={styles.headerButtonLink} to='/contact'>
+          <a className={styles.headerButtonLink} href='/contact'>
             <button className={styles.headerButtonDark}>Contact</button>
-          </Link>
+          </a>
         </div>
       </div>
 


### PR DESCRIPTION
Temp solution so forms subs are processed: link to contact page with anchor tags instead of `Link`. This is a stop gap so form subs work while I work on a more complete solution.