### PR TITLE
Issues/73 fixed dynamic header on small blog roll

### DIFF
--- a/src/components/blog-roll-small.js
+++ b/src/components/blog-roll-small.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import { StaticQuery, graphql, Link } from 'gatsby';
+import styles from './blog-roll-small.module.scss';
+
+const BlogRollSmall = ({ slug, category, header }) => (
+  <StaticQuery
+    query={graphql`
+      query blogRollSmall {
+        allContentfulBlogPost(sort: { fields: publishDate, order: DESC }) {
+          edges {
+            node {
+              category_ref {
+                name
+              }
+              slug
+              title
+              publishDate(formatString: "MMMM Do, YYYY")
+              heroImage {
+                description
+                file {
+                  url
+                }
+                title
+              }
+            }
+          }
+        }
+      }
+    `}
+    render={(data) => (
+      <div>
+        {data.allContentfulBlogPost.edges.filter(
+          (edge) =>
+            !category ||
+            (category === edge.node.category_ref.name &&
+              slug !== edge.node.slug)
+        ).length > 0 && header ? (
+          <div className={styles.blogRoll}>
+            <h3>{header}</h3>
+            <div className={styles.blogRollPosts}>
+              {data.allContentfulBlogPost.edges
+                .slice(0, 3)
+                .filter(
+                  (edge) =>
+                    !category ||
+                    (category === edge.node.category_ref.name &&
+                      slug !== edge.node.slug)
+                )
+                .map((edge, i) => {
+                  return (
+                    <Link
+                      className={styles.blogRollPostsLink}
+                      to={`/blog/${edge.node.slug}`}
+                      key={i}>
+                      <div className={styles.blogRollPostsLinkContainer}>
+                        <img
+                          src={edge.node.heroImage.file.url}
+                          alt={edge.node.heroImage.description}
+                          title={edge.node.heroImage.title}
+                        />
+                        <h2 className={styles.blogRollPostsLinkContainerHeader}>
+                          {edge.node.title}
+                        </h2>
+                      </div>
+                    </Link>
+                  );
+                })}
+            </div>
+          </div>
+        ) : (
+          ''
+        )}
+      </div>
+    )}></StaticQuery>
+);
+
+export default BlogRollSmall;

--- a/src/components/blog-roll-small.module.scss
+++ b/src/components/blog-roll-small.module.scss
@@ -1,0 +1,66 @@
+/*
+External Modules
+*/
+
+@use '../styles/variables.scss' as *;
+
+.blog-roll {
+  margin: $unitsMedium 0;
+}
+
+.blog-roll-posts {
+  display: flex;
+  flex-wrap: nowrap;
+  align-content: center;
+  justify-content: center;
+  align-items: stretch;
+  gap: 1rem;
+}
+
+a.blog-roll-posts-link {
+  margin: 0;
+  color: $white;
+  text-shadow: $textShadowMedium;
+  text-decoration: none;
+  min-width: 33%;
+}
+
+.blog-roll-posts-link-container {
+  position: relative;
+  // max-height: none;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  min-height: 8rem;
+  border: 1px solid $gray3;
+  border-radius: $smallBorderRadius;
+  box-shadow: $shadowMeduim;
+  transition: ease-in-out 0.15s transform, box-shadow;
+}
+
+.blog-roll-posts-link-container:hover {
+  transform: scale(1.025);
+  box-shadow: $shadowLarge;
+}
+
+div.blog-roll-posts-link-container > img {
+  position: absolute;
+  margin-bottom: 0;
+  border: none;
+  border-radius: 0;
+  min-height: -webkit-fill-available;
+  filter: brightness(0.9);
+}
+
+h2.blog-roll-posts-link-container-header {
+  margin: 0;
+  padding: $unitsMedium;
+  z-index: 1;
+}
+
+@media screen and (max-width: 767px) {
+  .blog-roll-posts {
+    flex-direction: column;
+  }
+}

--- a/src/components/blog-roll.js
+++ b/src/components/blog-roll.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { StaticQuery, graphql, Link } from 'gatsby';
 import styles from './blog-roll.module.scss';
 
+var match = '';
 const BlogRoll = ({ slug, category }) => (
   <StaticQuery
     query={graphql`
@@ -33,9 +34,11 @@ const BlogRoll = ({ slug, category }) => (
     render={(data) => (
       <div className={styles.blogRoll}>
         <div className={styles.blogRollPosts}>
+          {console.log(typeof data.allContentfulBlogPost.edges)}
           {data.allContentfulBlogPost.edges.map((edge, i) => {
             return !category ||
-              (category === edge.node.category && slug !== edge.node.slug) ? (
+              (category === edge.node.category_ref.name &&
+                slug !== edge.node.slug) ? (
               <Link
                 className={styles.blogRollPostsLink}
                 to={`/blog/${edge.node.slug}`}

--- a/src/components/blog-roll.js
+++ b/src/components/blog-roll.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { StaticQuery, graphql, Link } from 'gatsby';
 import styles from './blog-roll.module.scss';
 
-var match = '';
 const BlogRoll = ({ slug, category }) => (
   <StaticQuery
     query={graphql`
@@ -34,7 +33,6 @@ const BlogRoll = ({ slug, category }) => (
     render={(data) => (
       <div className={styles.blogRoll}>
         <div className={styles.blogRollPosts}>
-          {console.log(typeof data.allContentfulBlogPost.edges)}
           {data.allContentfulBlogPost.edges.map((edge, i) => {
             return !category ||
               (category === edge.node.category_ref.name &&

--- a/src/components/blog-roll.module.scss
+++ b/src/components/blog-roll.module.scss
@@ -21,7 +21,7 @@ a.blog-roll-posts-link {
   display: flex;
   align-items: center;
   overflow: hidden;
-  height: 10rem;
+  min-height: 8rem;
   margin: $unitsMedium 0;
   border: 1px solid $gray3;
   border-radius: $smallBorderRadius;
@@ -35,6 +35,7 @@ a.blog-roll-posts-link {
 }
 
 div.blog-roll-posts-link-container > img {
+  position: absolute;
   margin-bottom: 0;
   border: none;
   border-radius: 0;
@@ -43,5 +44,5 @@ div.blog-roll-posts-link-container > img {
 h2.blog-roll-posts-link-container-header {
   margin: 0;
   padding: $unitsMedium;
-  position: absolute;
+  z-index: 1;
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'gatsby';
 
 import Layout from '../components/layout';
-import BlogRoll from '../components/blog-roll';
+import BlogRollSmall from '../components/blog-roll-small';
 import SEO from '../components/seo';
 import styles from '../components/header.module.scss';
 
@@ -70,8 +70,7 @@ const Index = () => {
           and elegant solutions quickly.
         </p>
       </div>
-      <h3>Recent posts</h3>
-      <BlogRoll />
+      <BlogRollSmall header='Recent Posts' />
     </Layout>
   );
 };

--- a/src/templates/blogPost.js
+++ b/src/templates/blogPost.js
@@ -4,7 +4,7 @@ import { graphql } from 'gatsby';
 import Layout from '../components/layout';
 import SEO from '../components/seo';
 import VideoPlayer from '../components/video-player';
-import BlogRoll from '../components/blog-roll';
+import BlogRollSmall from '../components/blog-roll-small';
 
 import styles from './blog-post.module.scss';
 
@@ -169,9 +169,10 @@ const BlogPost = ({ data }) => {
         ''
       )}
 
-      <BlogRoll
+      <BlogRollSmall
         category={data.contentfulBlogPost.category_ref.name}
         slug={data.contentfulBlogPost.slug}
+        header='Related Posts'
       />
     </Layout>
   );


### PR DESCRIPTION
I finally figured out how to look for blogs with a similar category as the page where the component is being called if one's shared, and if there are any blogs in the array I set the header that's passed as a prop.

I achieved this with a new blog roll that's specifically used for "recent" and "similar" blog rolls, so every blog roll except the one on the blog page. This blog roll has the styling needed for a smaller blog roll and the logic to look for posts in the `edges` array.

This use of two rolls makes me wonder if there's a way to use a more elegant solution to downsize on code complexity. This could be done by putting the logic used in these two blog rolls into a component so it's only coded once (the logic is very similar between the two rolls). There might also be some other way to use one blog roll for all locations, maybe by dynamically setting the classes used in styling so small blog rolls could have posts side by side and the main blog roll wouldn't.

In addition to tightening up the code used on the blog roll logic, the styling is in need of some refactoring too. Now that the logic appears to be working, I think a complete overhaul of class selectors, the component stylesheets, and code organization is in order. It's as though the classes used in the component were a best guess to get something spun up, we might want to use a more intentional naming style, like BEM or something.

I think I'm going to close issue #73 since this has effectively placed the header in dynamically, however we'll need another ticket to capture any refactoring and drying of this code.