### PR TITLE
Mar 25 build clients

### DIFF
--- a/src/app/components/clients.tsx
+++ b/src/app/components/clients.tsx
@@ -1,14 +1,14 @@
 import type { Person } from '../types';
+import Article from '../templates/article';
 
-export default async function Clients(data: Person) {
+export default function Client(data: Person) {
   return (
-    <div id='clients'>
-      <section className='flex min-h-dscreen flex-col justify-center p-4'>
-        <h1 className='text-5xl font-black text-primary-600'>
-          Clients section
-        </h1>
-        <p>This area is coming soon, cmon.</p>
-      </section>
-    </div>
+    <Article
+      headline='Clients'
+      subhead="See who I've helped"
+      button={false}
+      data={data}>
+      <p>Hey this needs to be under the main hgroup</p>
+    </Article>
   );
 }

--- a/src/app/components/clients.tsx
+++ b/src/app/components/clients.tsx
@@ -1,33 +1,28 @@
 import type { Person } from '../types';
 import Article from '../templates/article';
 import GlobalCard from './shared/card';
-import type { ButtonSettings } from './shared/button';
 
 export default function Client(data: Person) {
-  const button: ButtonSettings = {
-    text: 'Read more',
-    size: 'small',
-    width: 'fit',
-    color: 'gray',
-    link: '/#contact',
-  };
   return (
     <Article
       headline='Clients'
       subhead="See who I've helped"
       button={false}
       data={data}>
-      <GlobalCard
-        logo={data.technology.items[0].icon}
-        icon={data.skills.items[0].icon}
-        header='Header'
-        subheader='Subheader'
-        shortDescription='Try to keep headline under 30 characters.'
-        longDescription='Try to keep headline under 60 characters.'
-        button={button}
-        verticalLine={true}
-        horizontalLine={true}
-      />
+      <div className='flex flex-wrap gap-4'>
+        {data.clients.items.map((client) => (
+          <div className='shrink grow md:basis-1/3 lg:basis-1/4'>
+            <GlobalCard
+              key={client.clientsCollection.items[0].name}
+              icon={client.clientsCollection.items[0].logo}
+              subheader={client.clientsCollection.items[0].name}
+              shortDescription={client.headline}
+              verticalLine={true}
+              horizontalLine={false}
+            />
+          </div>
+        ))}
+      </div>
     </Article>
   );
 }

--- a/src/app/components/clients.tsx
+++ b/src/app/components/clients.tsx
@@ -1,14 +1,33 @@
 import type { Person } from '../types';
 import Article from '../templates/article';
+import GlobalCard from './shared/card';
+import type { ButtonSettings } from './shared/button';
 
 export default function Client(data: Person) {
+  const button: ButtonSettings = {
+    text: 'Read more',
+    size: 'small',
+    width: 'fit',
+    color: 'gray',
+    link: '/#contact',
+  };
   return (
     <Article
       headline='Clients'
       subhead="See who I've helped"
       button={false}
       data={data}>
-      <p>Hey this needs to be under the main hgroup</p>
+      <GlobalCard
+        logo={data.technology.items[0].icon}
+        icon={data.skills.items[0].icon}
+        header='Header'
+        subheader='Subheader'
+        shortDescription='Try to keep headline under 30 characters.'
+        longDescription='Try to keep headline under 60 characters.'
+        button={button}
+        verticalLine={true}
+        horizontalLine={true}
+      />
     </Article>
   );
 }

--- a/src/app/components/contact.tsx
+++ b/src/app/components/contact.tsx
@@ -1,14 +1,12 @@
 import type { Person } from '../types';
+import Article from '../templates/article';
 
-export default async function Contact(data: Person) {
+export default function Client(data: Person) {
   return (
-    <div id='contact'>
-      <section className='flex min-h-dscreen flex-col justify-center p-4'>
-        <h1 className='text-5xl font-black text-primary-600'>
-          Contact section
-        </h1>
-        <p>This area is coming soon, cmon.</p>
-      </section>
-    </div>
+    <Article
+      headline='Consultation'
+      subhead='Let’s work together'
+      button={false}
+      data={data}></Article>
   );
 }

--- a/src/app/components/employers.tsx
+++ b/src/app/components/employers.tsx
@@ -1,14 +1,12 @@
 import type { Person } from '../types';
+import Article from '../templates/article';
 
-export default async function Employers(data: Person) {
+export default function Client(data: Person) {
   return (
-    <div id='employers'>
-      <section className='flex min-h-dscreen flex-col justify-center p-4'>
-        <h1 className='text-5xl font-black text-primary-600'>
-          Employers section
-        </h1>
-        <p>This area is coming soon, cmon.</p>
-      </section>
-    </div>
+    <Article
+      headline='Employers'
+      subhead='Let’s see where I’ve been'
+      button={false}
+      data={data}></Article>
   );
 }

--- a/src/app/components/hero.tsx
+++ b/src/app/components/hero.tsx
@@ -14,6 +14,7 @@ export default async function Hero(data: Person) {
       headline={data.headline}
       subhead={data.subhead}
       headshot={headshot}
+      button
     />
   );
 }

--- a/src/app/components/navigation.tsx
+++ b/src/app/components/navigation.tsx
@@ -22,7 +22,6 @@ export default function Navigation() {
       setClick(false);
     }
   }
-  console.log(click);
   return (
     <div className='relative font-bold'>
       <div className='relative h-16'>

--- a/src/app/components/navigation.tsx
+++ b/src/app/components/navigation.tsx
@@ -26,7 +26,7 @@ export default function Navigation() {
   return (
     <div className='relative font-bold'>
       <div className='relative h-16'>
-        <header className='fixed inset-x-0 flex justify-between items-center p-4 max-h-16 bg-gradient-to-b from-gray-0 to-gray-100 border-b border-b-gray-300'>
+        <header className='fixed inset-x-0 flex justify-between items-center px-2 h-16 bg-gradient-to-b from-gray-0 to-gray-100 border-b border-b-gray-300'>
           <Link className='text-xl font-black' href='/'>
             John Hodge
           </Link>

--- a/src/app/components/philosophy.tsx
+++ b/src/app/components/philosophy.tsx
@@ -1,14 +1,12 @@
 import type { Person } from '../types';
+import Article from '../templates/article';
 
-export default async function Philosophy(data: Person) {
+export default function Client(data: Person) {
   return (
-    <div id='philosophy'>
-      <section className='flex min-h-dscreen flex-col justify-center p-4'>
-        <h1 className='text-5xl font-black text-primary-600'>
-          Philosophy section
-        </h1>
-        <p>This area is coming soon, cmon.</p>
-      </section>
-    </div>
+    <Article
+      headline='Philosophy'
+      subhead='Let’s see what I prioritize'
+      button={false}
+      data={data}></Article>
   );
 }

--- a/src/app/components/shared/button.tsx
+++ b/src/app/components/shared/button.tsx
@@ -1,11 +1,11 @@
-type Button = {
+export type ButtonSettings = {
   size: 'small' | 'large';
   width: 'full' | 'fit';
   color: 'primary' | 'secondary' | 'gray';
   link: string;
   text: string;
 };
-export default function Button(props: Button) {
+export default function Button(props: ButtonSettings) {
   return (
     <a
       className={`inline-block border border-solid bg-gradient-to-b text-center font-bold ${

--- a/src/app/components/shared/button.tsx
+++ b/src/app/components/shared/button.tsx
@@ -20,7 +20,7 @@ export default function Button(props: Button) {
           : props.color == 'primary'
           ? 'border-primary-400 from-primary-100 to-primary-50 text-primary-700'
           : 'border-gray-400 from-gray-100 to-gray-50 text-gray-700'
-      } hover:scale-110 ease-in-out duration-150`}
+      } hover:scale-105 ease-in-out duration-150`}
       href={props.link}>
       {props.text}
     </a>

--- a/src/app/components/shared/button.tsx
+++ b/src/app/components/shared/button.tsx
@@ -20,7 +20,7 @@ export default function Button(props: Button) {
           : props.color == 'primary'
           ? 'border-primary-400 from-primary-100 to-primary-50 text-primary-700'
           : 'border-gray-400 from-gray-100 to-gray-50 text-gray-700'
-      }`}
+      } hover:scale-110 ease-in-out duration-150`}
       href={props.link}>
       {props.text}
     </a>

--- a/src/app/components/shared/card.tsx
+++ b/src/app/components/shared/card.tsx
@@ -6,10 +6,10 @@ import { ButtonSettings } from './button';
 type GlobalCard = {
   logo?: MediaImage;
   icon?: MediaImage;
-  header: string;
-  subheader: string;
-  shortDescription: string;
-  longDescription: string;
+  header?: string;
+  subheader?: string;
+  shortDescription?: string;
+  longDescription?: string;
   button?: ButtonSettings;
   verticalLine: boolean;
   horizontalLine: boolean;
@@ -17,7 +17,7 @@ type GlobalCard = {
 
 export default function GlobalCard(props: GlobalCard) {
   return (
-    <section>
+    <section className='bg-gradient-to-t to-gray-0 from-gray-100 shadow-md p-8 rounded-3xl flex flex-col gap-4'>
       {props.logo?.url ? (
         <figure>
           <Image
@@ -34,35 +34,68 @@ export default function GlobalCard(props: GlobalCard) {
         ''
       )}
 
-      <div>
-        {props.icon?.url ? (
-          <figure>
-            <Image
-              src={props.icon.url}
-              height={props.icon.height}
-              width={props.icon.width}
-              title={props.icon.title}
-              alt={props.icon.description}
-            />
-            <figcaption className='hidden'>{props.icon.description}</figcaption>
-          </figure>
+      <div className='flex flex-col gap-4'>
+        <hgroup className='flex gap-2'>
+          {props.icon?.url ? (
+            <figure className='flex flex-col justify-center'>
+              <Image
+                src={props.icon.url}
+                height={props.icon.height}
+                width={props.icon.width}
+                title={props.icon.title}
+                alt={props.icon.description}
+              />
+              <figcaption className='hidden'>
+                {props.icon.description}
+              </figcaption>
+            </figure>
+          ) : (
+            ''
+          )}
+          {props.subheader && props.shortDescription ? (
+            <div
+              className={`flex flex-col justify-center gap-4 ${
+                props.verticalLine ? 'border-l border-gray-950 pl-2' : ''
+              }`}>
+              {props.subheader ? (
+                <h3
+                  className='text-2xl font-extrabold
+              lg:text-4xl
+              xl:text-5xl'>
+                  {props.subheader}
+                </h3>
+              ) : (
+                ''
+              )}
+              {props.shortDescription ? <p>{props.shortDescription}</p> : ''}
+            </div>
+          ) : (
+            ''
+          )}
+        </hgroup>
+
+        {props.horizontalLine ? <hr className='border-gray-950' /> : ''}
+        {props.header ? (
+          <h2
+            className='text-5xl font-black 
+        lg:text-7xl
+        xl:text-8xl'>
+            {props.header}
+          </h2>
         ) : (
           ''
         )}
-        <div>
-          <h3>{props.subheader}</h3>
-          <p>{props.shortDescription}</p>
-        </div>
-        <h2>{props.header}</h2>
-        <p>{props.longDescription}</p>
+        {props.longDescription ? <p>{props.longDescription}</p> : ''}
         {props.button ? (
-          <Button
-            text={props.button.text}
-            size={props.button.size}
-            color={props.button.color}
-            width={props.button.width}
-            link={props.button.link}
-          />
+          <div className='self-auto'>
+            <Button
+              text={props.button.text}
+              size={props.button.size}
+              color={props.button.color}
+              width={props.button.width}
+              link={props.button.link}
+            />
+          </div>
         ) : (
           ''
         )}

--- a/src/app/components/shared/card.tsx
+++ b/src/app/components/shared/card.tsx
@@ -1,0 +1,72 @@
+import Image from 'next/image';
+import type { MediaImage } from '@/app/types';
+import Button from './button';
+import { ButtonSettings } from './button';
+
+type GlobalCard = {
+  logo?: MediaImage;
+  icon?: MediaImage;
+  header: string;
+  subheader: string;
+  shortDescription: string;
+  longDescription: string;
+  button?: ButtonSettings;
+  verticalLine: boolean;
+  horizontalLine: boolean;
+};
+
+export default function GlobalCard(props: GlobalCard) {
+  return (
+    <section>
+      {props.logo?.url ? (
+        <figure>
+          <Image
+            src={props.logo.url}
+            height={props.logo.height}
+            width={props.logo.width}
+            title={props.logo.title}
+            alt={props.logo.description}
+            className='h-6'
+          />
+          <figcaption className='hidden'>{props.logo.description}</figcaption>
+        </figure>
+      ) : (
+        ''
+      )}
+
+      <div>
+        {props.icon?.url ? (
+          <figure>
+            <Image
+              src={props.icon.url}
+              height={props.icon.height}
+              width={props.icon.width}
+              title={props.icon.title}
+              alt={props.icon.description}
+            />
+            <figcaption className='hidden'>{props.icon.description}</figcaption>
+          </figure>
+        ) : (
+          ''
+        )}
+        <div>
+          <h3>{props.subheader}</h3>
+          <p>{props.shortDescription}</p>
+        </div>
+        <h2>{props.header}</h2>
+        <p>{props.longDescription}</p>
+        {props.button ? (
+          <Button
+            text={props.button.text}
+            size={props.button.size}
+            color={props.button.color}
+            width={props.button.width}
+            link={props.button.link}
+          />
+        ) : (
+          ''
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/app/components/shared/card.tsx
+++ b/src/app/components/shared/card.tsx
@@ -45,9 +45,10 @@ export default function GlobalCard(props: GlobalCard) {
                 title={props.icon.title}
                 alt={props.icon.description}
               />
-              <figcaption className='hidden'>
-                {props.icon.description}
-              </figcaption>
+              <figcaption
+                className='hidden'
+                dangerouslySetInnerHTML={{ __html: props.icon.description }}
+              />
             </figure>
           ) : (
             ''
@@ -61,13 +62,19 @@ export default function GlobalCard(props: GlobalCard) {
                 <h3
                   className='text-2xl font-extrabold
               lg:text-4xl
-              xl:text-5xl'>
-                  {props.subheader}
-                </h3>
+              xl:text-5xl'
+                  dangerouslySetInnerHTML={{ __html: props.subheader }}
+                />
               ) : (
                 ''
               )}
-              {props.shortDescription ? <p>{props.shortDescription}</p> : ''}
+              {props.shortDescription ? (
+                <p
+                  dangerouslySetInnerHTML={{ __html: props.shortDescription }}
+                />
+              ) : (
+                ''
+              )}
             </div>
           ) : (
             ''
@@ -79,13 +86,17 @@ export default function GlobalCard(props: GlobalCard) {
           <h2
             className='text-5xl font-black 
         lg:text-7xl
-        xl:text-8xl'>
-            {props.header}
-          </h2>
+        xl:text-8xl'
+            dangerouslySetInnerHTML={{ __html: props.header }}
+          />
         ) : (
           ''
         )}
-        {props.longDescription ? <p>{props.longDescription}</p> : ''}
+        {props.longDescription ? (
+          <p dangerouslySetInnerHTML={{ __html: props.longDescription }} />
+        ) : (
+          ''
+        )}
         {props.button ? (
           <div className='self-auto'>
             <Button

--- a/src/app/components/skills.tsx
+++ b/src/app/components/skills.tsx
@@ -1,12 +1,12 @@
 import type { Person } from '../types';
+import Article from '../templates/article';
 
-export default async function Skills(data: Person) {
+export default function Client(data: Person) {
   return (
-    <div id='skills'>
-      <section className='flex min-h-dscreen flex-col justify-center p-4'>
-        <h1 className='text-5xl font-black text-primary-600'>Skills section</h1>
-        <p>This area is coming soon, cmon.</p>
-      </section>
-    </div>
+    <Article
+      headline='Skills'
+      subhead='Let’s see what I know'
+      button={false}
+      data={data}></Article>
   );
 }

--- a/src/app/components/tech.tsx
+++ b/src/app/components/tech.tsx
@@ -1,12 +1,12 @@
 import type { Person } from '../types';
+import Article from '../templates/article';
 
-export default async function Tech(data: Person) {
+export default function Client(data: Person) {
   return (
-    <div id='tech'>
-      <section className='flex min-h-dscreen flex-col justify-center p-4'>
-        <h1 className='text-5xl font-black text-primary-600'>Tech section</h1>
-        <p>This area is coming soon, cmon.</p>
-      </section>
-    </div>
+    <Article
+      headline='Tech'
+      subhead='Let’s see what I use'
+      button={false}
+      data={data}></Article>
   );
 }

--- a/src/app/components/testimonials.tsx
+++ b/src/app/components/testimonials.tsx
@@ -1,14 +1,12 @@
 import type { Person } from '../types';
+import Article from '../templates/article';
 
-export default async function Testimonials(data: Person) {
+export default function Client(data: Person) {
   return (
-    <div id='testimonials'>
-      <section className='flex min-h-dscreen flex-col justify-center p-4'>
-        <h1 className='text-5xl font-black text-primary-600'>
-          Testimonials section
-        </h1>
-        <p>This area is coming soon, cmon.</p>
-      </section>
-    </div>
+    <Article
+      headline='Testimonials'
+      subhead='Let’s see what they’re saying'
+      button={false}
+      data={data}></Article>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -35,17 +35,41 @@ export default async function Home() {
   );
   const json = await response.json();
   const data: Person = json.data.person;
-
+  const start = 65;
+  const end = 100;
+  const lowSaturation = 0;
+  const highSaturation = 100;
   return (
     <main>
       <Hero {...data} />
-      <Clients {...data} />
-      <Employers {...data} />
-      <Testimonials {...data} />
-      <Skills {...data} />
-      <Tech {...data} />
-      <Philosophy {...data} />
-      <Contact {...data} />
+      <div
+        className={`bg-gradient-to-b from-gray-${lowSaturation} from-${start}% to-primary-${highSaturation} to-${end}%`}>
+        <Clients {...data} />
+      </div>
+      <div
+        className={`bg-gradient-to-b from-primary-${highSaturation} from-${start}% to-gray-${highSaturation} to-${end}%`}>
+        <Employers {...data} />
+      </div>
+      <div
+        className={`bg-gradient-to-b from-gray-${highSaturation} from-${start}% to-gray-${lowSaturation} to-${end}%`}>
+        <Testimonials {...data} />
+      </div>
+      <div
+        className={`bg-gradient-to-b from-gray-${lowSaturation} from-${start}% to-secondary-${highSaturation} to-${end}%`}>
+        <Skills {...data} />
+      </div>
+      <div
+        className={`bg-gradient-to-b from-secondary-${highSaturation} from-${start}% to-gray-${highSaturation} to-${end}%`}>
+        <Tech {...data} />
+      </div>
+      <div
+        className={`bg-gradient-to-b from-to-gray-100 from-${start}% to-gray-0 to-${end}%`}>
+        <Philosophy {...data} />
+      </div>
+      <div
+        className={`bg-gradient-to-b from-gray-0 from-${start}% to-primary-100 to-${end}%`}>
+        <Contact {...data} />
+      </div>
     </main>
   );
 }

--- a/src/app/templates/article.tsx
+++ b/src/app/templates/article.tsx
@@ -11,8 +11,8 @@ type Hgroup = {
 };
 export default function Article(props: Hgroup) {
   return (
-    <article className='px-2 py-9'>
-      <div className='flex flex-col md:flex-row gap-9'>
+    <article className='mx-2 py-9 border-b border-gray-800'>
+      <div className='flex flex-col-reverse gap-9 md:flex-row'>
         <hgroup className='basis-2/3 grow flex flex-col items-start gap-9'>
           <section className='flex flex-col'>
             <h2

--- a/src/app/templates/article.tsx
+++ b/src/app/templates/article.tsx
@@ -58,7 +58,7 @@ export default function Article(props: Hgroup) {
           ''
         )}
       </div>
-      {props.children}
+      <section className='py-9'>{props.children}</section>
     </article>
   );
 }

--- a/src/app/templates/article.tsx
+++ b/src/app/templates/article.tsx
@@ -11,7 +11,7 @@ type Hgroup = {
 };
 export default function Article(props: Hgroup) {
   return (
-    <article className='mx-2 py-9 border-b border-gray-800'>
+    <article className='mx-2 py-9 border-b border-gray-950'>
       <div className='flex flex-col-reverse gap-9 md:flex-row'>
         <hgroup className='basis-2/3 grow flex flex-col items-start gap-9'>
           <section className='flex flex-col'>

--- a/src/app/templates/article.tsx
+++ b/src/app/templates/article.tsx
@@ -1,61 +1,64 @@
 import Button from '../components/shared/button';
 import Image from 'next/image';
-import type { MediaImage } from '@/app/types';
+import type { MediaImage, Person } from '@/app/types';
 type Hgroup = {
   headline: string;
   subhead: string;
+  button: boolean;
+  data?: Person;
   headshot?: MediaImage;
+  children?: React.ReactNode;
 };
-export default function Article(
-  props: Hgroup,
-  { children }: { children?: React.ReactNode } = {}
-) {
+export default function Article(props: Hgroup) {
   return (
-    <article
-      className='flex flex-col px-4 py-9 gap-9
-      md:flex-row'>
-      <hgroup className='basis-2/3 grow flex flex-col items-start gap-9'>
-        <section>
-          <h2
-            className='text-5xl font-black pb-6
+    <article className='px-2 py-9'>
+      <div className='flex flex-col md:flex-row gap-9'>
+        <hgroup className='basis-2/3 grow flex flex-col items-start gap-9'>
+          <section className='flex flex-col'>
+            <h2
+              className='text-5xl font-black pb-6
             lg:text-7xl
             xl:text-8xl'
-            dangerouslySetInnerHTML={{ __html: props.headline }}
-          />
-          <h3
-            className='text-2xl font-extrabold
+              dangerouslySetInnerHTML={{ __html: props.headline }}
+            />
+            <h3
+              className='text-2xl font-extrabold
             lg:text-4xl
             xl:text-5xl'
-            dangerouslySetInnerHTML={{ __html: props.subhead }}
-          />
-        </section>
-
-        <Button
-          size='large'
-          color='secondary'
-          link='/#contact'
-          width='fit'
-          text='Schedule a consultation'
-        />
-      </hgroup>
-      {props.headshot?.url ? (
-        <figure className='basis-1/3'>
-          <Image
-            src={props.headshot.url}
-            height={props.headshot.height}
-            width={props.headshot.width}
-            title={props.headshot.title}
-            alt={props.headshot.description}
-            className='aspect-ratio-1/1'
-          />
-          <figcaption className='text-primary-700 bg-primary-50 px-2'>
-            {props.headshot.description}
-          </figcaption>
-        </figure>
-      ) : (
-        ''
-      )}
-      {children}
+              dangerouslySetInnerHTML={{ __html: props.subhead }}
+            />
+          </section>
+          {props.button ? (
+            <Button
+              size='large'
+              color='secondary'
+              link='/#contact'
+              width='fit'
+              text='Schedule a consultation'
+            />
+          ) : (
+            ''
+          )}
+        </hgroup>
+        {props.headshot?.url ? (
+          <figure className='basis-1/3'>
+            <Image
+              src={props.headshot.url}
+              height={props.headshot.height}
+              width={props.headshot.width}
+              title={props.headshot.title}
+              alt={props.headshot.description}
+              className='aspect-ratio-1/1'
+            />
+            <figcaption className='text-primary-700 bg-primary-50 px-2'>
+              {props.headshot.description}
+            </figcaption>
+          </figure>
+        ) : (
+          ''
+        )}
+      </div>
+      {props.children}
     </article>
   );
 }

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -50,13 +50,9 @@ type BasicPerson = {
 };
 
 type Testimonials = {
-  items: [
-    {
-      excerpt: string;
-      body: string;
-      author: BasicPerson;
-    }
-  ];
+  excerpt: string;
+  body: string;
+  author: BasicPerson;
 };
 
 export type HeroData = {
@@ -69,10 +65,10 @@ export interface Person extends BasicPerson {
   sys: [Object];
   headline: string;
   subhead: string;
-  skills: [BasicPost];
-  technology: [BasicPost];
-  philosophy: [BasicPost];
-  employment: Employment;
-  clients: Clients;
-  testimonials: Testimonials;
+  skills: { items: [BasicPost] };
+  technology: { items: [BasicPost] };
+  philosophy: { items: [[BasicPost]] };
+  employment: { items: [Employment] };
+  clients: { items: [Clients] };
+  testimonials: { items: [Testimonials] };
 }


### PR DESCRIPTION
I made the global card component, set all the props to optional, and coded the card structure to be adaptive to different combinations of props.

I also updated the article component to set the padding around the incoming children. For consistency, I think it'd be best to use `div`s in the specific components for the homepage (clients, employers, etc). The contents of the children are wrapped in a `section` tag in the article component. The article component also uses decently organized semantic html, so there shouldn't be a sense of urgency to use html that's more semantic than `div`s. Hopefully that relieves some cognitive load, we can work with `div`s inside these components and not end up with a website that's all `div`s since semantic html is being handled with some scale in other components.

This picture shows how the contents inside the `clients` component appear in production. I think maintaining this consistency should be easy given how the article component is structured.

<img width="636" alt="Screenshot 2023-06-23 at 13 59 20" src="https://github.com/johnhodge/johnhodge/assets/18251637/a13f1ba8-6ec6-4378-ba3e-92f2d5a302b1">

