### PR TITLE
MAR-47 add reporting only CSP and report-to

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -15,6 +15,18 @@ const nextConfig = {
     ],
   },
   async headers() {
+    const CSP = `
+    report-uri https://hodge.report-uri.com/r/d/csp/reportOnly
+    default-src 'none';
+    script-src 'self' 'unsafe-inline' 'unsafe-eval' *.googletagmanager.com *.hotjar.com *.hs-scripts.com *.hscollectedforms.net *.hscollectedforms.com *.hs-analytics.net *.hs-banner.com *.doubleclick.net analytics.google.com;
+    connect-src 'self' *.mixpanel.com analytics.google.com *.hscollectedforms.net;
+    font-src 'self';
+    style-src-elem 'self';
+    style-src 'unsafe-inline';
+    img-src 'self' images.ctfassets.net *.hubspot.com *.google.com forms.hsforms.com data:;
+    base-uri 'self';
+    form-action 'self';
+    `;
     return [
       {
         source: '/',
@@ -22,6 +34,14 @@ const nextConfig = {
           {
             key: 'X-XSS-Protection',
             value: '1; mode=block',
+          },
+          {
+            key: 'Content-Security-Policy-Report-Only',
+            value: CSP.replace(/\s{2,}/g, ' ').trim(),
+          },
+          {
+            key: 'Report-To',
+            value: `{group: 'default', max_age: 31536000, endpoints: [{ url: 'https://hodge.report-uri.com/a/d/g' }],include_subdomains: true,}`,
           },
           {
             key: 'x-whatcha-looking-for',


### PR DESCRIPTION
In this PR I created the CSP and the reporting system. I have the CSP set up usiing Content-Security-Policy-Report-Only. When we feel confident that the policy works in production we can set it to Content-Security-Policy.