### PR TITLE
Mar 58 main docs page

### DIFF
--- a/documentation/_index.mdx
+++ b/documentation/_index.mdx
@@ -1,0 +1,9 @@
+---
+title: 'Docs'
+excerpt: 'See how my site is built.'
+icon: '5kxfpzEXHIPNSZVKHNZX9L'
+date: '2023-07-18T05:35:07.322Z'
+author:
+  firstName: John
+  lastName: Hodge
+---

--- a/documentation/development-process/_index.mdx
+++ b/documentation/development-process/_index.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Development Process'
-excerpt: 'This is a sample index page.'
+excerpt: 'Agile, prioritization and roadmap management, prototyping, CI/CD, and documentation approval processes.'
 icon: '5kxfpzEXHIPNSZVKHNZX9L'
 date: '2023-07-18T05:35:07.322Z'
 author:

--- a/documentation/media/_index.mdx
+++ b/documentation/media/_index.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Media'
-excerpt: 'This is a sample index page.'
+excerpt: 'Dynamic favicon and open graph icon creation, custom image loader, variable fonts, and safely responsive font-sizing.'
 icon: '5QK88qN8kaLhSi3dmbh7Hs'
 date: '2023-07-18T05:35:07.322Z'
 author:

--- a/documentation/security-and-compliance/_index.mdx
+++ b/documentation/security-and-compliance/_index.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Secutity and Compliance'
+title: 'Security and Compliance'
 excerpt: 'Content-security policy process, Report URI dashboard, and GDPR policy enforcement.'
 icon: '3ljyU4EZnfara3J2GeWY1k'
 date: '2023-07-18T05:35:07.322Z'

--- a/documentation/security-and-compliance/_index.mdx
+++ b/documentation/security-and-compliance/_index.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Secutity and Compliance'
-excerpt: 'This is a sample index page.'
+excerpt: 'Content-security policy process, Report URI dashboard, and GDPR policy enforcement.'
 icon: '3ljyU4EZnfara3J2GeWY1k'
 date: '2023-07-18T05:35:07.322Z'
 author:

--- a/documentation/tagging-and-analytics/_index.mdx
+++ b/documentation/tagging-and-analytics/_index.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Tagging and Analytics'
-excerpt: 'This is a sample index page.'
+excerpt: 'Google Tag Manager, Analytics, Mixpanel event configuration, and HubSpot data pipeline.'
 icon: '4ANek8zEO6usqE5ovWHkAI'
 date: '2023-07-18T05:35:07.322Z'
 author:

--- a/documentation/utilities-back-end/_index.mdx
+++ b/documentation/utilities-back-end/_index.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Utilities Back End'
-excerpt: 'This is a sample index page.'
+title: 'Utilities Back-End'
+excerpt: 'NextJS meta framework, package management, GraphQL querying system.'
 icon: '3I7Cu42jAluQ9OckRUMq3g'
 date: '2023-07-18T05:35:07.322Z'
 author:

--- a/documentation/utilities-front-end/_index.mdx
+++ b/documentation/utilities-front-end/_index.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Utilities Front End'
-excerpt: 'This is a sample index page.'
+title: 'Utilities Front-End'
+excerpt: 'Shared React components, libraries, languages, and markups.'
 icon: '5zG4XpluWdzDOY7F6nUGSm'
 date: '2023-07-18T05:35:07.322Z'
 author:

--- a/src/app/components/shared/card.tsx
+++ b/src/app/components/shared/card.tsx
@@ -3,10 +3,12 @@ import type { MediaImage } from '@/app/types';
 import GlobalPopover from './popover';
 import GlobalButton, { GlobalButtonSettings } from './button';
 import MarkUp from '@/utils/markup';
+import GetAsset from '@/utils/asset';
 
 export type GlobalCardSettings = {
   logo?: MediaImage;
   icon?: MediaImage;
+  iconId?: string;
   iconAlign?: 'start' | 'center' | 'end';
   header?: string;
   subheader?: string;
@@ -50,7 +52,7 @@ export default function GlobalCard(props: GlobalCardSettings) {
 
       <div className='flex flex-col gap-4'>
         <hgroup className='flex gap-2'>
-          {props.icon?.url ? (
+          {props.icon ? (
             <figure
               className={`flex flex-col w-icon min-w-icon justify-${
                 props.iconAlign ? props.iconAlign : 'center'
@@ -71,6 +73,13 @@ export default function GlobalCard(props: GlobalCardSettings) {
                 dangerouslySetInnerHTML={{ __html: props.icon.description }}
               />
             </figure>
+          ) : props.iconId ? (
+            <GetAsset
+              figcaption={false}
+              assetId={props.iconId}
+              priority={true}
+              size='fit'
+            />
           ) : (
             ''
           )}

--- a/src/app/docs/(categories)/[category]/page.tsx
+++ b/src/app/docs/(categories)/[category]/page.tsx
@@ -37,6 +37,7 @@ function createButton(link: string): GlobalButtonSettings {
     color: 'primary',
     link: link,
     text: 'Read more',
+    route: true,
   };
 }
 

--- a/src/app/docs/(categories)/templates/doc.tsx
+++ b/src/app/docs/(categories)/templates/doc.tsx
@@ -36,7 +36,9 @@ export async function generateMetadata(props: PropParams) {
 }
 
 export default function Doc(props: PropParams) {
-  const folders = readdirSync(props.docsDirectoryPath);
+  const folders = readdirSync(props.docsDirectoryPath).filter(
+    (folder) => folder != '_index.mdx'
+  );
   function getTOC(folders: string[]): Record<string, TOCEnteries> {
     const TOCItems: Record<string, TOCEnteries> = {};
     folders.forEach(

--- a/src/app/docs/components/body.tsx
+++ b/src/app/docs/components/body.tsx
@@ -2,7 +2,6 @@ import Link from 'next/link';
 import { ReactNode } from 'react';
 
 type MdData = {
-  section?: string;
   title?: string;
   excerpt?: string;
   coverImage?: string;
@@ -65,6 +64,28 @@ export function H2(props: Props) {
   );
 }
 
+export function TOCHome(props: Props) {
+  const headerAnchor = props.header
+    ?.toString()
+    .replaceAll(' ', '-')
+    .replaceAll('.', '')
+    .toLowerCase();
+  return (
+    <Link
+      href={`${props.base}${
+        props.header
+          ? `/#${headerAnchor}`
+          : props.slug
+          ? `/${props.slug?.replace('.mdx', '')}`
+          : ''
+      }`}
+      className='no-underline hover:text-secondary-600 transition-colors ease-in-out duration-50'>
+      <div id={headerAnchor} className='py-2 font-extrabold text-lg'>
+        {props.data ? props.data.title : props.header}
+      </div>
+    </Link>
+  );
+}
 export function TOC2(props: Props) {
   const headerAnchor = props.header
     ?.toString()
@@ -87,7 +108,6 @@ export function TOC2(props: Props) {
     </Link>
   );
 }
-
 export function TOC3(props: Props) {
   const headerAnchor = props.header
     ?.toString()

--- a/src/app/docs/components/toc.tsx
+++ b/src/app/docs/components/toc.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { TOC2, TOC3 } from '@/app/docs/components/body';
+import { TOC2, TOC3, TOCHome } from '@/app/docs/components/body';
 import Link from 'next/link';
 import { join } from 'path';
 import { useState } from 'react';
@@ -13,27 +13,39 @@ type PropData = {
 };
 
 export function TOC(props: PropData) {
+  const homeData = { title: 'Docs Home' };
   return (
-    <div className='max-h-full py-4 overflow-y-auto prose z-40 overscroll-none md:z-auto md:max-h-[calc(75dvh-110px)]'>
-      {Object.keys(props.folders).map((dir) => (
-        <>
-          <TOC2
-            key={props.folders[dir].root.title.replace(' ', '-').toLowerCase()}
-            base={join('/', 'docs', dir)}
-            data={props.folders[dir].root}
-          />
-
-          {props.folders[dir].subPages.map((subPage) => (
-            <TOC3
-              key={subPage.title.replace(' ', '-').toLowerCase()}
+    <>
+      <p className='pb-4 text-xl font-black'>Contents</p>
+      <div className='max-h-full py-4 overflow-y-auto prose z-40 overscroll-none md:z-auto md:max-h-[calc(75dvh-110px)]'>
+        <TOCHome
+          key='docs-home'
+          base={join('/', 'docs')}
+          slug='/'
+          data={homeData}
+        />
+        {Object.keys(props.folders).map((dir) => (
+          <>
+            <TOC2
+              key={props.folders[dir].root.title
+                .replace(' ', '-')
+                .toLowerCase()}
               base={join('/', 'docs', dir)}
-              slug={subPage.fileName}
-              data={subPage}
+              data={props.folders[dir].root}
             />
-          ))}
-        </>
-      ))}
-    </div>
+
+            {props.folders[dir].subPages.map((subPage) => (
+              <TOC3
+                key={subPage.title.replace(' ', '-').toLowerCase()}
+                base={join('/', 'docs', dir)}
+                slug={subPage.fileName}
+                data={subPage}
+              />
+            ))}
+          </>
+        ))}
+      </div>
+    </>
   );
 }
 
@@ -49,53 +61,11 @@ export default function GlobalTOC(props: PropData) {
   return (
     <>
       <div className='md:hidden sticky z-30 top-20'>
-        <svg
+        <span
           onClick={handleClick}
-          width='40'
-          height='44'
-          viewBox='0 0 40 44'
-          fill='none'
-          xmlns='https://www.w3.org/2000/svg'>
-          <rect
-            x='38'
-            y='42'
-            width='36'
-            height='40'
-            rx='2'
-            transform='rotate(-180 38 42)'
-            className='fill-gray-100'
-          />
-          <path
-            d='M30 30L10 30'
-            className='stroke-gray-900'
-            stroke-width='4'
-            stroke-linecap='round'
-          />
-          <path
-            d='M30 22L10 22'
-            className='stroke-gray-900'
-            strokeWidth='4'
-            strokeLinecap='round'
-          />
-          <path
-            d='M30 14L10 14'
-            className='stroke-gray-900'
-            strokeWidth='4'
-            strokeLinecap='round'
-          />
-          <rect
-            x='38'
-            y='42'
-            width='36'
-            height='40'
-            rx='2'
-            transform='rotate(-180 38 42)'
-            className='stroke-gray-500'
-            strokeWidth='2'
-            strokeLinecap='round'
-            strokeLinejoin='round'
-          />
-        </svg>
+          className='rounded-lg min-w-fit inline-block p-1 text-3xl text-center border border-solid bg-gradient-to-b border-gray-400 from-gray-100 to-gray-50 text-gray-700 '>
+          📖
+        </span>
 
         <div className='relative z-40 overflow-hidden'>
           <div
@@ -131,7 +101,6 @@ export default function GlobalTOC(props: PropData) {
       </div>
       <aside className='hidden md:block col-span-2'>
         <div className='sticky top-32'>
-          <p className='pb-4 text-xl font-black'>Category</p>
           <TOC {...props} />
           <div className='pt-4 border-t border-t-gray-200 flex flex-col items-start justify-center'>
             <p>Written by: {props.author}</p>

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -1,5 +1,98 @@
+import GlobalCard from '@/app/components/shared/card';
+import { readFileSync, readdirSync } from 'fs';
+import matter from 'gray-matter';
+import { Metadata } from 'next';
+import { join } from 'path';
 import { cwd } from 'process';
+import Article from '../templates/article';
+import { GlobalButtonSettings } from '../components/shared/button';
 
-export default function Docs() {
-  return cwd();
+const docsDirectoryPath = join(cwd(), 'documentation');
+export async function generateMetadata() {
+  const MDXFilePath = join(docsDirectoryPath, '_index.mdx');
+  const fileContents = readFileSync(join(MDXFilePath));
+  const { data } = matter(fileContents);
+  const metadata: Metadata = {
+    title: data.title,
+  };
+
+  return metadata;
+}
+
+type SubPageData = {
+  filename: string;
+  title: string;
+  excerpt: string;
+  icon: string;
+};
+
+function createButton(link: string): GlobalButtonSettings {
+  return {
+    size: 'small',
+    width: 'fit',
+    color: 'primary',
+    link: link,
+    text: 'Read more',
+  };
+}
+
+export default async function Page() {
+  const subPages: Record<string, SubPageData> = {};
+  const subPageDirs = readdirSync(docsDirectoryPath);
+  subPageDirs
+    .filter((file: string) => file != '_index.mdx')
+    .map((subPageDir: string) =>
+      readdirSync(join(docsDirectoryPath, subPageDir))
+        .filter((page) => page == '_index.mdx')
+        .map(
+          (subPage) =>
+            (subPages[subPageDir] = {
+              filename: subPage,
+              title: matter(
+                readFileSync(
+                  join(docsDirectoryPath, subPageDir, subPage),
+                  'utf-8'
+                )
+              ).data.title,
+              excerpt: matter(
+                readFileSync(
+                  join(docsDirectoryPath, subPageDir, subPage),
+                  'utf-8'
+                )
+              ).data.excerpt,
+              icon: matter(
+                readFileSync(
+                  join(docsDirectoryPath, subPageDir, subPage),
+                  'utf-8'
+                )
+              ).data.icon,
+            })
+        )
+    );
+
+  return (
+    <Article
+      id={'docs'}
+      headline={
+        matter(readFileSync(join(docsDirectoryPath, '_index.mdx'))).data.title
+      }
+      subhead={
+        matter(readFileSync(join(docsDirectoryPath, '_index.mdx'))).data.excerpt
+      }>
+      <div className='grid grid-cols-6 gap-4'>
+        {Object.keys(subPages).map((page) => (
+          <div className='col-span-6 lg:col-span-3 xl:col-span-2'>
+            <GlobalCard
+              verticalLine={false}
+              horizontalLine={true}
+              iconId={subPages[page].icon}
+              subheader={subPages[page].title}
+              longDescription={subPages[page].excerpt}
+              button={createButton(join('/docs', page))}
+            />
+          </div>
+        ))}
+      </div>
+    </Article>
+  );
 }

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -33,6 +33,7 @@ function createButton(link: string): GlobalButtonSettings {
     color: 'primary',
     link: link,
     text: 'Read more',
+    route: true,
   };
 }
 
@@ -71,28 +72,33 @@ export default async function Page() {
     );
 
   return (
-    <Article
-      id={'docs'}
-      headline={
-        matter(readFileSync(join(docsDirectoryPath, '_index.mdx'))).data.title
-      }
-      subhead={
-        matter(readFileSync(join(docsDirectoryPath, '_index.mdx'))).data.excerpt
-      }>
-      <div className='grid grid-cols-6 gap-4'>
-        {Object.keys(subPages).map((page) => (
-          <div className='col-span-6 lg:col-span-3 xl:col-span-2'>
-            <GlobalCard
-              verticalLine={false}
-              horizontalLine={true}
-              iconId={subPages[page].icon}
-              subheader={subPages[page].title}
-              longDescription={subPages[page].excerpt}
-              button={createButton(join('/docs', page))}
-            />
-          </div>
-        ))}
-      </div>
-    </Article>
+    <div className='bg-gradient-to-b from-gray-0 from-60% to-secondary-100 to-100%'>
+      <Article
+        id={'docs'}
+        headline={
+          matter(readFileSync(join(docsDirectoryPath, '_index.mdx'))).data.title
+        }
+        subhead={
+          matter(readFileSync(join(docsDirectoryPath, '_index.mdx'))).data
+            .excerpt
+        }>
+        <div className='grid grid-cols-6 gap-4'>
+          {Object.keys(subPages).map((page) => (
+            <div
+              className='col-span-6 lg:col-span-3 xl:col-span-2'
+              key={subPages[page].icon}>
+              <GlobalCard
+                verticalLine={false}
+                horizontalLine={true}
+                iconId={subPages[page].icon}
+                subheader={subPages[page].title}
+                longDescription={subPages[page].excerpt}
+                button={createButton(join('/docs', page))}
+              />
+            </div>
+          ))}
+        </div>
+      </Article>
+    </div>
   );
 }

--- a/src/utils/asset.tsx
+++ b/src/utils/asset.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image';
 
-type ImageData = {
+export type ImageData = {
   metadata: {
     tags: Array<string>;
   };
@@ -47,6 +47,7 @@ type asset = {
   assetId: string;
   figcaption: boolean;
   priority: boolean;
+  size?: 'fit' | 'full';
 };
 export default async function GetAsset(props: asset) {
   const url = `https://cdn.contentful.com/spaces/${process.env.PUBLIC_CONTENTFUL_SPACE_ID}/environments/production/assets/${props.assetId}?access_token=${process.env.PUBLIC_CONTENTFUL_CONTENT_DELIVERY_TOKEN}`;
@@ -54,7 +55,7 @@ export default async function GetAsset(props: asset) {
   const imageData: ImageData = await res.json();
 
   return (
-    <figure className='w-full'>
+    <figure className={props.size != 'fit' ? 'w-full' : 'w-fit'}>
       <Image
         src={`https:${imageData.fields.file.url}`}
         height={imageData.fields.file.details.image.height}


### PR DESCRIPTION
In this PR I created the docs main page and made a few minor updates to pages besides the main docs page and the TOC icon on mobile but those were mostly small tweaks. 

I had to adjust the card to support regular links and popover buttons, we used to only support popovers which won't work for this part of the website.

The largest update I had outside the main docs page was allowing cards to source assets from the asset id using the `GetAsset` component. I also had to make a minor change to that component so I could set the width to either be full or fit. This would allow me to resize SVGs to fill all available space (like near the contact page) or confine the width (like in the icons on cards for this PR).