### PR TITLE
MAR-64-use-mdx-provider

### DIFF
--- a/documentation/development-process/_index.mdx
+++ b/documentation/development-process/_index.mdx
@@ -8,7 +8,35 @@ author:
   lastName: Hodge
 ---
 
+import GlobalCallout from '@/src/app/docs/components/callouts';
+
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget.
+
+<GlobalCallout
+  message="
+It's worth noting that Joey's a fat bastard who literally no one likes
+"
+  type='alert'
+/>
+<GlobalCallout
+  message="
+It's worth noting that Joey's a fat bastard who literally no one likes
+"
+  type='note'
+/>
+<GlobalCallout
+  message="
+It's worth noting that Joey's a fat bastard who literally no one likes
+"
+  type='success'
+/>
+<GlobalCallout
+  message="
+  It's worth noting that Joey's a fat bastard who literally no one likes. Praesent elementum facilisis leo vel fringilla. Congue mauris rhoncus aenean vel. Egestas sed tempus urna et pharetra pharetra massa massa ultricies.
+
+"
+type='warning'
+/>
 
 ## Lorem Ipsum
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@headlessui/react": "^1.7.15",
     "@hookform/resolvers": "^3.1.1",
     "@mdx-js/loader": "^2.3.0",
-    "@mdx-js/react": "^2.3.0",
     "@next/mdx": "^13.4.9",
     "@tiptap/pm": "^2.0.3",
     "gray-matter": "^4.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,12 +10,9 @@ dependencies:
   '@mdx-js/loader':
     specifier: ^2.3.0
     version: 2.3.0(webpack@5.88.1)
-  '@mdx-js/react':
-    specifier: ^2.3.0
-    version: 2.3.0(react@18.2.0)
   '@next/mdx':
     specifier: ^13.4.9
-    version: 13.4.9(@mdx-js/loader@2.3.0)(@mdx-js/react@2.3.0)
+    version: 13.4.9(@mdx-js/loader@2.3.0)
   '@tiptap/pm':
     specifier: ^2.0.3
     version: 2.0.3(@tiptap/core@2.0.3)
@@ -756,7 +753,7 @@ packages:
       glob: 7.1.7
     dev: true
 
-  /@next/mdx@13.4.9(@mdx-js/loader@2.3.0)(@mdx-js/react@2.3.0):
+  /@next/mdx@13.4.9(@mdx-js/loader@2.3.0):
     resolution: {integrity: sha512-6ALqgOUsHWFWCl5LaYM96RzjBb/+Ca8IxVLhyZ4ukOZkFlYXInJmVLZhXWDxes7b8iVMMKZNgvNJR9dKLaGAQw==}
     peerDependencies:
       '@mdx-js/loader': '>=0.15.0'
@@ -768,7 +765,6 @@ packages:
         optional: true
     dependencies:
       '@mdx-js/loader': 2.3.0(webpack@5.88.1)
-      '@mdx-js/react': 2.3.0(react@18.2.0)
       source-map: 0.7.4
     dev: false
 

--- a/src/app/docs/(categories)/[category]/page.tsx
+++ b/src/app/docs/(categories)/[category]/page.tsx
@@ -1,11 +1,10 @@
+import type { GlobalButtonSettings } from '@/app/components/shared/button';
 import GlobalCard from '@/app/components/shared/card';
 import Doc from '@/app/docs/(categories)/templates/doc';
-import { readFileSync, readdirSync } from 'fs';
-import matter from 'gray-matter';
+import { GetDataContent, GetSubFolders } from '@/utils/mdx';
 import { Metadata } from 'next';
 import { join } from 'path';
 import { cwd } from 'process';
-import type { GlobalButtonSettings } from '@/app/components/shared/button';
 
 type PropParams = {
   params: {
@@ -21,8 +20,7 @@ export async function generateMetadata(props: PropParams) {
     props.params.category.replace('.mdx', '')
   );
   const MDXFilePath = join(MDXFileDirectory, '_index.mdx');
-  const fileContents = readFileSync(join(MDXFilePath));
-  const { data } = matter(fileContents);
+  const { data } = GetDataContent(join(MDXFilePath));
   const metadata: Metadata = {
     title: data.title,
   };
@@ -54,14 +52,12 @@ export default async function Page(props: PropParams) {
   );
   const MDXFilePath = join(MDXDirectoryPath, '_index.mdx');
 
-  const subPageFiles = readdirSync(MDXDirectoryPath);
+  const subPageFiles = GetSubFolders(MDXDirectoryPath);
   subPageFiles.forEach(
     (file: string) =>
       (subPages[file] = {
-        title: matter(readFileSync(join(MDXDirectoryPath, file), 'utf-8')).data
-          .title,
-        descrption: matter(readFileSync(join(MDXDirectoryPath, file), 'utf-8'))
-          .data.excerpt,
+        title: GetDataContent(join(MDXDirectoryPath, file)).data.title,
+        descrption: GetDataContent(join(MDXDirectoryPath, file)).data.excerpt,
       })
   );
 
@@ -79,12 +75,10 @@ export default async function Page(props: PropParams) {
                 verticalLine={false}
                 horizontalLine={true}
                 subheader={
-                  matter(readFileSync(join(MDXDirectoryPath, page), 'utf-8'))
-                    .data.title
+                  GetDataContent(join(MDXDirectoryPath, page)).data.title
                 }
                 longDescription={
-                  matter(readFileSync(join(MDXDirectoryPath, page), 'utf-8'))
-                    .data.excerpt
+                  GetDataContent(join(MDXDirectoryPath, page)).data.excerpt
                 }
                 button={createButton(
                   join(props.params.category, page.replace('.mdx', ''))

--- a/src/app/docs/components/callouts.tsx
+++ b/src/app/docs/components/callouts.tsx
@@ -1,0 +1,24 @@
+export type CalloutData = {
+  message: string;
+  type: 'warning' | 'alert' | 'note' | 'success';
+};
+
+export default function GlobalCallout(props: CalloutData) {
+  const color = {
+    success: `text-primary-900 bg-primary-50  border-primary-500`,
+    alert: `text-secondary-900 bg-secondary-50  border-secondary-500`,
+    warning: `text-red-900 bg-red-50  border-red-500`,
+    note: `text-sky-900 bg-sky-50  border-sky-500`,
+  };
+  const icon = { success: '✅', alert: '⚠️', warning: '⛔️', note: 'ℹ️' };
+
+  return (
+    <div
+      className={`my-4 p-4 rounded-lg flex align-top gap-2 border ${
+        color[props.type]
+      }`}>
+      <span className='font-emoji'>{icon[props.type]}</span>
+      <span>{props.message}</span>
+    </div>
+  );
+}

--- a/src/app/docs/components/toc.tsx
+++ b/src/app/docs/components/toc.tsx
@@ -1,9 +1,9 @@
 'use client';
+import type { TOCEnteries } from '@/app/docs/(categories)/templates/doc';
 import { TOC2, TOC3, TOCHome } from '@/app/docs/components/body';
 import Link from 'next/link';
 import { join } from 'path';
 import { useState } from 'react';
-import type { TOCEnteries } from '../(categories)/templates/doc';
 
 type PropData = {
   docsDirectoryPath: string;
@@ -25,24 +25,22 @@ export function TOC(props: PropData) {
           data={homeData}
         />
         {Object.keys(props.folders).map((dir) => (
-          <>
+          <div key={dir}>
             <TOC2
-              key={props.folders[dir].root.title
-                .replace(' ', '-')
-                .toLowerCase()}
+              key={dir}
               base={join('/', 'docs', dir)}
               data={props.folders[dir].root}
             />
 
             {props.folders[dir].subPages.map((subPage) => (
               <TOC3
-                key={subPage.title.replace(' ', '-').toLowerCase()}
+                key={join(subPage.fileName)}
                 base={join('/', 'docs', dir)}
                 slug={subPage.fileName}
                 data={subPage}
               />
             ))}
-          </>
+          </div>
         ))}
       </div>
     </>
@@ -63,7 +61,7 @@ export default function GlobalTOC(props: PropData) {
       <div className='md:hidden sticky z-30 top-20'>
         <span
           onClick={handleClick}
-          className='rounded-lg min-w-fit inline-block p-1 text-3xl text-center border border-solid bg-gradient-to-b border-gray-400 from-gray-100 to-gray-50 text-gray-700 '>
+          className='font-emoji rounded-lg min-w-fit inline-block p-1 text-3xl text-center border border-solid bg-gradient-to-b border-gray-400 from-gray-100 to-gray-50 text-gray-700 '>
           📖
         </span>
 

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -1,17 +1,15 @@
+import { GlobalButtonSettings } from '@/app/components/shared/button';
 import GlobalCard from '@/app/components/shared/card';
-import { readFileSync, readdirSync } from 'fs';
-import matter from 'gray-matter';
+import Article from '@/app/templates/article';
+import { GetDataContent, GetSubFolders } from '@/utils/mdx';
 import { Metadata } from 'next';
 import { join } from 'path';
 import { cwd } from 'process';
-import Article from '../templates/article';
-import { GlobalButtonSettings } from '../components/shared/button';
 
 const docsDirectoryPath = join(cwd(), 'documentation');
 export async function generateMetadata() {
   const MDXFilePath = join(docsDirectoryPath, '_index.mdx');
-  const fileContents = readFileSync(join(MDXFilePath));
-  const { data } = matter(fileContents);
+  const { data } = GetDataContent(join(MDXFilePath));
   const metadata: Metadata = {
     title: data.title,
   };
@@ -39,34 +37,24 @@ function createButton(link: string): GlobalButtonSettings {
 
 export default async function Page() {
   const subPages: Record<string, SubPageData> = {};
-  const subPageDirs = readdirSync(docsDirectoryPath);
+  const subPageDirs = GetSubFolders(docsDirectoryPath);
   subPageDirs
     .filter((file: string) => file != '_index.mdx')
     .map((subPageDir: string) =>
-      readdirSync(join(docsDirectoryPath, subPageDir))
+      GetSubFolders(join(docsDirectoryPath, subPageDir))
         .filter((page) => page == '_index.mdx')
         .map(
           (subPage) =>
             (subPages[subPageDir] = {
               filename: subPage,
-              title: matter(
-                readFileSync(
-                  join(docsDirectoryPath, subPageDir, subPage),
-                  'utf-8'
-                )
+              title: GetDataContent(
+                join(docsDirectoryPath, subPageDir, subPage)
               ).data.title,
-              excerpt: matter(
-                readFileSync(
-                  join(docsDirectoryPath, subPageDir, subPage),
-                  'utf-8'
-                )
+              excerpt: GetDataContent(
+                join(docsDirectoryPath, subPageDir, subPage)
               ).data.excerpt,
-              icon: matter(
-                readFileSync(
-                  join(docsDirectoryPath, subPageDir, subPage),
-                  'utf-8'
-                )
-              ).data.icon,
+              icon: GetDataContent(join(docsDirectoryPath, subPageDir, subPage))
+                .data.icon,
             })
         )
     );
@@ -76,11 +64,10 @@ export default async function Page() {
       <Article
         id={'docs'}
         headline={
-          matter(readFileSync(join(docsDirectoryPath, '_index.mdx'))).data.title
+          GetDataContent(join(docsDirectoryPath, '_index.mdx')).data.title
         }
         subhead={
-          matter(readFileSync(join(docsDirectoryPath, '_index.mdx'))).data
-            .excerpt
+          GetDataContent(join(docsDirectoryPath, '_index.mdx')).data.excerpt
         }>
         <div className='grid grid-cols-6 gap-4'>
           {Object.keys(subPages).map((page) => (

--- a/src/utils/git-branch.sh
+++ b/src/utils/git-branch.sh
@@ -1,6 +1,0 @@
-branch=$(git symbolic-ref HEAD 2> /dev/null | awk 'BEGIN{FS="/"} {print $NF}')
-if [[ $branch == "" ]]; then
-  echo 'main'
-else
-  echo $branch
-fi

--- a/src/utils/mdx.tsx
+++ b/src/utils/mdx.tsx
@@ -1,0 +1,13 @@
+import { readFileSync, readdirSync } from 'fs';
+import matter from 'gray-matter';
+
+export function GetDataContent(fileLocation: string) {
+  const fileContents = readFileSync(fileLocation);
+  const { data, content } = matter(fileContents);
+  return { data, content };
+}
+
+export function GetSubFolders(directoryLocation: string) {
+  const folders = readdirSync(directoryLocation);
+  return folders;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,6 +8,9 @@ module.exports = {
   ],
   theme: {
     extend: {
+      fontFamily: {
+        emoji: ['Apple Color Emoji'],
+      },
       spacing: {
         icon: '3rem',
       },


### PR DESCRIPTION
In this PR, I experimented with MDXProvider but it requires the use of context, which means we need to use client. But then we couldn't access node:fs so we wouldn't be able to access the mdx files we're trying to compile.

It turns out, just changing the key to be something else that would be present and unique helped. I also was able to eliminate unnecessary components by mapping them to `null`.

In the process of working on this, I moved the file and dirsync functions to their own module. That seems to be a cleaner approach, and even though the main reason I did that was to work around some of the limitations of MDXProvider, I'm going to leave that as is.

I also built a component for generating callouts and tested out how we would comile those. It's pretty intuitive and we could do it for more custom components.