### PR TITLE
MAR-74-github-and-typing-refactor

### DIFF
--- a/documentation/development-process/ci-cd-pipeline.mdx
+++ b/documentation/development-process/ci-cd-pipeline.mdx
@@ -1,13 +1,11 @@
 ---
-section: Test
 title: 'CI/CD Pipeline'
 excerpt: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget. At imperdiet dui accumsan sit amet nulla facilities morbi tempus.'
-coverImage: '/assets/blog/preview/cover.jpg'
+icon: '/assets/blog/preview/cover.jpg'
 date: '2023-07-18T05:35:07.322Z'
 author:
-  name: John Hodge
-ogImage:
-  url: '/no-image.jpeg'
+  firstName: John
+  lastName: Hodge
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo vel fringilla est ullamcorper eget.

--- a/src/app/docs/(categories)/[category]/[slug]/page.tsx
+++ b/src/app/docs/(categories)/[category]/[slug]/page.tsx
@@ -1,45 +1,47 @@
 import Doc from '@/app/docs/(categories)/templates/doc';
-import { readFileSync } from 'fs';
-import matter from 'gray-matter';
+import { DynamicRoute, PostData } from '@/app/types';
+import { GetDataContent } from '@/utils/mdx';
 import { Metadata } from 'next';
 import { join } from 'path';
 import { cwd } from 'process';
 
-type PropParams = {
-  params: {
-    slug: string;
-    category: string;
-  };
-};
+const rootDocsDirectory = join(cwd(), 'documentation');
 
-const docsDirectoryPath = join(cwd(), 'documentation');
-
-export async function generateMetadata(props: PropParams) {
-  const MDXFilePath = join(
-    docsDirectoryPath,
+export async function generateMetadata(props: DynamicRoute) {
+  const MDXFilePath: string = join(
+    rootDocsDirectory,
     props.params.category.replace('.mdx', ''),
     `${props.params.slug}.mdx`
   );
-  const fileContents = readFileSync(join(MDXFilePath));
-  const { data } = matter(fileContents);
+  const { data } = GetDataContent(join(MDXFilePath));
   const metadata: Metadata = {
     title: data.title,
   };
-
   return metadata;
 }
 
-export default function Page(props: PropParams) {
-  const MDXFilePath = join(
-    docsDirectoryPath,
+export default function Page(props: DynamicRoute) {
+  const MDXFilePath: string = join(
+    rootDocsDirectory,
     props.params.category.replace('.mdx', ''),
     `${props.params.slug}.mdx`
   );
-  return (
-    <Doc
-      params={props.params}
-      docsDirectoryPath={docsDirectoryPath}
-      MDXFilePath={MDXFilePath}
-    />
-  );
+  const { data } = GetDataContent(join(MDXFilePath));
+  const post: PostData = {
+    title: data.title,
+    excerpt: data.excerpt,
+    date: data.date,
+    icon: data.icon,
+    author: {
+      firstName: data.author.firstName,
+      lastName: data.author.lastName,
+    },
+    file: {
+      rootDocsDirectory: rootDocsDirectory,
+      containingDirectory: join(rootDocsDirectory, props.params.category),
+      fileName: `${props.params.slug}.mdx`,
+      MDXFilePath: MDXFilePath,
+    },
+  };
+  return <Doc route={props} post={post} />;
 }

--- a/src/app/docs/components/body.tsx
+++ b/src/app/docs/components/body.tsx
@@ -1,20 +1,13 @@
+import { PostData } from '@/app/types';
 import Link from 'next/link';
+import { join } from 'path';
 import { ReactNode } from 'react';
 
-type MdData = {
-  title?: string;
-  excerpt?: string;
-  coverImage?: string;
-  date?: string;
-  author?: { name: string };
-  ogImage?: { url: string };
-};
-
-type Props = {
+type Header = {
   base: string;
   header?: ReactNode;
   children?: ReactNode;
-  data?: MdData;
+  data?: PostData;
   slug?: string;
 };
 
@@ -34,7 +27,7 @@ export default function LinkedHeader(props: LinkedHeaderProps) {
   );
 }
 
-export function H3(props: Props) {
+export function H3(props: Header) {
   const headerAnchor = props.header
     ?.toString()
     .replaceAll(' ', '-')
@@ -49,7 +42,7 @@ export function H3(props: Props) {
   );
 }
 
-export function H2(props: Props) {
+export function H2(props: Header) {
   const headerAnchor = props.header
     ?.toString()
     .replaceAll(' ', '-')
@@ -64,29 +57,18 @@ export function H2(props: Props) {
   );
 }
 
-export function TOCHome(props: Props) {
-  const headerAnchor = props.header
-    ?.toString()
-    .replaceAll(' ', '-')
-    .replaceAll('.', '')
-    .toLowerCase();
+export function TOCHome(props: Header) {
   return (
     <Link
-      href={`${props.base}${
-        props.header
-          ? `/#${headerAnchor}`
-          : props.slug
-          ? `/${props.slug?.replace('.mdx', '')}`
-          : ''
-      }`}
+      href={join(props.base, props.slug ?? '')}
       className='no-underline hover:text-primary-700 transition-colors ease-in-out duration-50'>
-      <div id={headerAnchor} className='py-2 font-extrabold text-lg'>
+      <div className='py-2 font-extrabold text-lg'>
         {props.data ? props.data.title : props.header}
       </div>
     </Link>
   );
 }
-export function TOC2(props: Props) {
+export function TOC2(props: Header) {
   const headerAnchor = props.header
     ?.toString()
     .replaceAll(' ', '-')
@@ -108,7 +90,7 @@ export function TOC2(props: Props) {
     </Link>
   );
 }
-export function TOC3(props: Props) {
+export function TOC3(props: Header) {
   const headerAnchor = props.header
     ?.toString()
     .replaceAll(' ', '-')

--- a/src/app/docs/components/github.tsx
+++ b/src/app/docs/components/github.tsx
@@ -1,56 +1,42 @@
 import Link from 'next/link';
+import type { PostData } from '@/app/types';
 
-type AuthorData = {
-  firstName: string;
-  lastName: string;
-};
-type PostData = {
-  section: string;
-  title: string;
-  excerpt: string;
-  coverImage: string;
-  date: string;
-  ogImage: string;
-};
-type PropsData = {
-  fullPath: string;
-  author: AuthorData;
-  postData?: PostData;
-};
-export default function GitHubData(props: PropsData) {
-  <div className='pt-4 border-t bg-gray-0 border-t300 flex flex-col items-start justify-center'>
-    <p>
-      Written by: {props.author.firstName} {props.author.lastName}
-    </p>
-    <Link
-      className='py-2 flex items-center gap-1'
-      title='Edit on GitHub'
-      target='_blank'
-      href={`https://github.com/johnhodge/johnhodge/blob/${
-        process.env.VERCEL_ENV == 'production' ? 'main' : 'canary'
-      }/${props.fullPath.replace(/.*\/johnhodge\//, '')}`}>
-      <svg
-        className='inline-block'
-        width='16'
-        height='16'
-        viewBox='0 0 16 16'
-        fill='none'
-        xmlns='https://www.w3.org/2000/svg'>
-        <g clipPath='url(#clip0_195_13624)'>
-          <path
-            className='fill-gray-900'
-            fillRule='evenodd'
-            clipRule='evenodd'
-            d='M8 0C3.58 0 0 3.58 0 8C0 11.54 2.29 14.53 5.47 15.59C5.87 15.66 6.02 15.42 6.02 15.21C6.02 15.02 6.01 14.39 6.01 13.72C4 14.09 3.48 13.23 3.32 12.78C3.23 12.55 2.84 11.84 2.5 11.65C2.22 11.5 1.82 11.13 2.49 11.12C3.12 11.11 3.57 11.7 3.72 11.94C4.44 13.15 5.59 12.81 6.05 12.6C6.12 12.08 6.33 11.73 6.56 11.53C4.78 11.33 2.92 10.64 2.92 7.58C2.92 6.71 3.23 5.99 3.74 5.43C3.66 5.23 3.38 4.41 3.82 3.31C3.82 3.31 4.49 3.1 6.02 4.13C6.66 3.95 7.34 3.86 8.02 3.86C8.7 3.86 9.38 3.95 10.02 4.13C11.55 3.09 12.22 3.31 12.22 3.31C12.66 4.41 12.38 5.23 12.3 5.43C12.81 5.99 13.12 6.7 13.12 7.58C13.12 10.65 11.25 11.33 9.47 11.53C9.76 11.78 10.01 12.26 10.01 13.01C10.01 14.08 10 14.94 10 15.21C10 15.42 10.15 15.67 10.55 15.59C13.71 14.53 16 11.53 16 8C16 3.58 12.42 0 8 0Z'
-          />
-        </g>
-        <defs>
-          <clipPath id='clip0_195_13624'>
-            <rect width='16' height='16' fill='none' />
-          </clipPath>
-        </defs>
-      </svg>
-      Edit on GitHub ↗
-    </Link>
-  </div>;
+export default function GitHubData(props: PostData) {
+  return (
+    <div className='pt-4 border-t border-t-gray-900 flex flex-col items-start justify-center'>
+      <p>
+        Written by: {props.author.firstName} {props.author.lastName}
+      </p>
+      <Link
+        className='py-2 flex items-center gap-1'
+        target='_blank'
+        href={`https://github.com/johnhodge/johnhodge/blob/canary/${props.file.MDXFilePath.replace(
+          /.*\/documentation\//,
+          'documentation/'
+        )}`}>
+        <svg
+          className='inline-block'
+          width='16'
+          height='16'
+          viewBox='0 0 16 16'
+          fill='none'
+          xmlns='https://www.w3.org/2000/svg'>
+          <g clipPath='url(#clip0_195_13624)'>
+            <path
+              className='fill-gray-900'
+              fillRule='evenodd'
+              clipRule='evenodd'
+              d='M8 0C3.58 0 0 3.58 0 8C0 11.54 2.29 14.53 5.47 15.59C5.87 15.66 6.02 15.42 6.02 15.21C6.02 15.02 6.01 14.39 6.01 13.72C4 14.09 3.48 13.23 3.32 12.78C3.23 12.55 2.84 11.84 2.5 11.65C2.22 11.5 1.82 11.13 2.49 11.12C3.12 11.11 3.57 11.7 3.72 11.94C4.44 13.15 5.59 12.81 6.05 12.6C6.12 12.08 6.33 11.73 6.56 11.53C4.78 11.33 2.92 10.64 2.92 7.58C2.92 6.71 3.23 5.99 3.74 5.43C3.66 5.23 3.38 4.41 3.82 3.31C3.82 3.31 4.49 3.1 6.02 4.13C6.66 3.95 7.34 3.86 8.02 3.86C8.7 3.86 9.38 3.95 10.02 4.13C11.55 3.09 12.22 3.31 12.22 3.31C12.66 4.41 12.38 5.23 12.3 5.43C12.81 5.99 13.12 6.7 13.12 7.58C13.12 10.65 11.25 11.33 9.47 11.53C9.76 11.78 10.01 12.26 10.01 13.01C10.01 14.08 10 14.94 10 15.21C10 15.42 10.15 15.67 10.55 15.59C13.71 14.53 16 11.53 16 8C16 3.58 12.42 0 8 0Z'
+            />
+          </g>
+          <defs>
+            <clipPath id='clip0_195_13624'>
+              <rect width='16' height='16' fill='none' />
+            </clipPath>
+          </defs>
+        </svg>
+        Edit on GitHub ↗
+      </Link>
+    </div>
+  );
 }

--- a/src/app/docs/components/toc.tsx
+++ b/src/app/docs/components/toc.tsx
@@ -1,19 +1,11 @@
 'use client';
-import type { TOCEnteries } from '@/app/docs/(categories)/templates/doc';
 import { TOC2, TOC3, TOCHome } from '@/app/docs/components/body';
+import { TOCData } from '@/app/types';
 import Link from 'next/link';
 import { join } from 'path';
 import { useState } from 'react';
 
-type PropData = {
-  docsDirectoryPath: string;
-  folders: Record<string, TOCEnteries>;
-  author: string;
-  MDXFilePath: string;
-};
-
-export default function GlobalTOC(props: PropData) {
-  const homeData = { title: 'Docs Home' };
+export default function GlobalTOC(props: TOCData) {
   const [click, setClick] = useState(false);
   function handleClick() {
     if (!click) {
@@ -61,12 +53,7 @@ export default function GlobalTOC(props: PropData) {
             </svg>
             <p className='pb-4 text-xl font-black'>Contents</p>
             <div className='max-h-full py-4 overflow-y-auto prose z-40 overscroll-none md:z-auto md:max-h-[calc(75dvh-110px)]'>
-              <TOCHome
-                key='docs-home'
-                base={join('/', 'docs')}
-                slug='/'
-                data={homeData}
-              />
+              <TOCHome key='docs-home' base={join('/', 'docs')} slug='/' />
               {Object.keys(props.folders).map((dir) => (
                 <div key={dir}>
                   <span onClick={handleClick}>
@@ -78,11 +65,13 @@ export default function GlobalTOC(props: PropData) {
                   </span>
 
                   {props.folders[dir].subPages.map((subPage) => (
-                    <span key={join(subPage.fileName)} onClick={handleClick}>
+                    <span
+                      key={join(subPage.file.fileName)}
+                      onClick={handleClick}>
                       <TOC3
-                        key={join(subPage.fileName)}
+                        key={join(subPage.file.fileName)}
                         base={join('/', 'docs', dir)}
-                        slug={subPage.fileName}
+                        slug={subPage.file.fileName}
                         data={subPage}
                       />
                     </span>
@@ -99,9 +88,9 @@ export default function GlobalTOC(props: PropData) {
           <div className='max-h-full py-4 overflow-y-auto prose z-40 overscroll-none md:z-auto md:max-h-[calc(75dvh-110px)]'>
             <TOCHome
               key='docs-home'
+              header='Docs Home'
               base={join('/', 'docs')}
               slug='/'
-              data={homeData}
             />
             {Object.keys(props.folders).map((dir) => (
               <div key={dir}>
@@ -113,9 +102,9 @@ export default function GlobalTOC(props: PropData) {
 
                 {props.folders[dir].subPages.map((subPage) => (
                   <TOC3
-                    key={join(subPage.fileName)}
+                    key={join(subPage.file.fileName)}
                     base={join('/', 'docs', dir)}
-                    slug={subPage.fileName}
+                    slug={subPage.file.fileName}
                     data={subPage}
                   />
                 ))}
@@ -123,11 +112,14 @@ export default function GlobalTOC(props: PropData) {
             ))}
           </div>
           <div className='pt-4 border-t border-t-gray-300 flex flex-col items-start justify-center'>
-            <p>Written by: {props.author}</p>
+            <p>
+              Written by: {props.post.author.firstName}{' '}
+              {props.post.author.lastName}
+            </p>
             <Link
               className='py-2 flex items-center gap-1'
               target='_blank'
-              href={`https://github.com/johnhodge/johnhodge/blob/canary/${props.MDXFilePath.replace(
+              href={`https://github.com/johnhodge/johnhodge/blob/canary/${props.post.file.MDXFilePath.replace(
                 /.*\/documentation\//,
                 'documentation/'
               )}`}>

--- a/src/app/docs/components/toc.tsx
+++ b/src/app/docs/components/toc.tsx
@@ -1,9 +1,9 @@
 'use client';
 import { TOC2, TOC3, TOCHome } from '@/app/docs/components/body';
 import { TOCData } from '@/app/types';
-import Link from 'next/link';
 import { join } from 'path';
 import { useState } from 'react';
+import GitHubData from './github';
 
 export default function GlobalTOC(props: TOCData) {
   const [click, setClick] = useState(false);
@@ -23,36 +23,38 @@ export default function GlobalTOC(props: TOCData) {
           📖
         </span>
 
-        <div className='relative z-40 overflow-hidden'>
-          <div
+        <div className='relative z-40 overflow-hidden md:hidden'>
+          <nav
             className={`${
               !click ? 'translate-x-full ' : 'translate-x-0 '
-            }fixed inset-0 w-full bg-gray-0 py-4 px-2 ease-in-out duration-300 delay-75`}>
-            <svg
-              onClick={handleClick}
-              className='absolute right-4'
-              width='30'
-              height='30'
-              viewBox='0 0 30 30'
-              fill='none'
-              xmlns='https://www.w3.org/2000/svg'>
-              <g clipPath='url(#clip0_64_6659)'>
-                <path
-                  d='M3 3L27 27M3 27L27 3'
-                  strokeWidth='4'
-                  strokeLinecap='round'
-                  strokeLinejoin='round'
-                  className='stroke-gray-900'
-                />
-              </g>
-              <defs>
-                <clipPath id='clip0_64_6659'>
-                  <rect width='30' height='30' className='fill-gray-0' />
-                </clipPath>
-              </defs>
-            </svg>
-            <p className='pb-4 text-xl font-black'>Contents</p>
-            <div className='max-h-full py-4 overflow-y-auto prose z-40 overscroll-none md:z-auto md:max-h-[calc(75dvh-110px)]'>
+            }fixed flex flex-col inset-0 w-full bg-gray-0 py-4 px-2 ease-in-out duration-300 delay-75`}>
+            <div className='h-8 relative flex items-center'>
+              <svg
+                onClick={handleClick}
+                className='absolute right-0'
+                width='30'
+                height='30'
+                viewBox='0 0 30 30'
+                fill='none'
+                xmlns='https://www.w3.org/2000/svg'>
+                <g clipPath='url(#clip0_64_6659)'>
+                  <path
+                    d='M3 3L27 27M3 27L27 3'
+                    strokeWidth='4'
+                    strokeLinecap='round'
+                    strokeLinejoin='round'
+                    className='stroke-gray-900'
+                  />
+                </g>
+                <defs>
+                  <clipPath id='clip0_64_6659'>
+                    <rect width='30' height='30' className='fill-gray-0' />
+                  </clipPath>
+                </defs>
+              </svg>
+              <p className='absolute text-xl font-black'>Contents</p>
+            </div>
+            <div className='max-h-full py-6 overflow-y-auto prose z-40 overscroll-none'>
               <TOCHome
                 key='docs-home'
                 header='Docs Home'
@@ -84,7 +86,7 @@ export default function GlobalTOC(props: TOCData) {
                 </div>
               ))}
             </div>
-          </div>
+          </nav>
         </div>
       </div>
       <aside className='hidden md:block col-span-2'>
@@ -116,42 +118,7 @@ export default function GlobalTOC(props: TOCData) {
               </div>
             ))}
           </div>
-          <div className='pt-4 border-t border-t-gray-300 flex flex-col items-start justify-center'>
-            <p>
-              Written by: {props.post.author.firstName}{' '}
-              {props.post.author.lastName}
-            </p>
-            <Link
-              className='py-2 flex items-center gap-1'
-              target='_blank'
-              href={`https://github.com/johnhodge/johnhodge/blob/canary/${props.post.file.MDXFilePath.replace(
-                /.*\/documentation\//,
-                'documentation/'
-              )}`}>
-              <svg
-                className='inline-block'
-                width='16'
-                height='16'
-                viewBox='0 0 16 16'
-                fill='none'
-                xmlns='https://www.w3.org/2000/svg'>
-                <g clipPath='url(#clip0_195_13624)'>
-                  <path
-                    className='fill-gray-900'
-                    fillRule='evenodd'
-                    clipRule='evenodd'
-                    d='M8 0C3.58 0 0 3.58 0 8C0 11.54 2.29 14.53 5.47 15.59C5.87 15.66 6.02 15.42 6.02 15.21C6.02 15.02 6.01 14.39 6.01 13.72C4 14.09 3.48 13.23 3.32 12.78C3.23 12.55 2.84 11.84 2.5 11.65C2.22 11.5 1.82 11.13 2.49 11.12C3.12 11.11 3.57 11.7 3.72 11.94C4.44 13.15 5.59 12.81 6.05 12.6C6.12 12.08 6.33 11.73 6.56 11.53C4.78 11.33 2.92 10.64 2.92 7.58C2.92 6.71 3.23 5.99 3.74 5.43C3.66 5.23 3.38 4.41 3.82 3.31C3.82 3.31 4.49 3.1 6.02 4.13C6.66 3.95 7.34 3.86 8.02 3.86C8.7 3.86 9.38 3.95 10.02 4.13C11.55 3.09 12.22 3.31 12.22 3.31C12.66 4.41 12.38 5.23 12.3 5.43C12.81 5.99 13.12 6.7 13.12 7.58C13.12 10.65 11.25 11.33 9.47 11.53C9.76 11.78 10.01 12.26 10.01 13.01C10.01 14.08 10 14.94 10 15.21C10 15.42 10.15 15.67 10.55 15.59C13.71 14.53 16 11.53 16 8C16 3.58 12.42 0 8 0Z'
-                  />
-                </g>
-                <defs>
-                  <clipPath id='clip0_195_13624'>
-                    <rect width='16' height='16' fill='none' />
-                  </clipPath>
-                </defs>
-              </svg>
-              Edit on GitHub ↗
-            </Link>
-          </div>
+          <GitHubData {...props.post} />
         </div>
       </aside>
     </>

--- a/src/app/docs/components/toc.tsx
+++ b/src/app/docs/components/toc.tsx
@@ -53,7 +53,12 @@ export default function GlobalTOC(props: TOCData) {
             </svg>
             <p className='pb-4 text-xl font-black'>Contents</p>
             <div className='max-h-full py-4 overflow-y-auto prose z-40 overscroll-none md:z-auto md:max-h-[calc(75dvh-110px)]'>
-              <TOCHome key='docs-home' base={join('/', 'docs')} slug='/' />
+              <TOCHome
+                key='docs-home'
+                header='Docs Home'
+                base={join('/', 'docs')}
+                slug='/'
+              />
               {Object.keys(props.folders).map((dir) => (
                 <div key={dir}>
                   <span onClick={handleClick}>

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -1,3 +1,5 @@
+import { ReactNode } from 'react';
+
 export type PersonMeta = {
   firstName: string;
   lastName: string;
@@ -70,3 +72,50 @@ export interface Person extends BasicPerson {
   clients: { items: [Clients] };
   testimonials: { items: [Testimonials] };
 }
+
+export type DynamicRoute = {
+  params: {
+    slug?: string;
+    category: string;
+  };
+};
+
+export type DynamicTemplate = {
+  route: DynamicRoute;
+  children?: ReactNode;
+  post: PostData;
+};
+
+export type FileData = {
+  rootDocsDirectory: string;
+  containingDirectory: string;
+  fileName: string;
+  MDXFilePath: string;
+};
+
+type AuthorData = {
+  firstName: string;
+  lastName: string;
+};
+
+export type SubPageData = {
+  title: string;
+  excerpt: string;
+};
+
+export interface PostData extends SubPageData {
+  icon: string;
+  date: string;
+  author: AuthorData;
+  file: FileData;
+}
+
+export type TOCData = {
+  post: PostData;
+  folders: Record<string, TOCEnteries>;
+};
+
+export type TOCEnteries = {
+  root: PostData;
+  subPages: PostData[];
+};


### PR DESCRIPTION
In this PR, I refactored the types and moved them to the types.ts file. I left some types in the body file. The components in that file will be reworked in MAR-75 - I think that ticket will benefit from a minor refactor on these components since there's a lot of duplication. The types on those components should be reworked in a way that better supports this deduplication.