### PR TITLE
MAR-76 update ternary on card for buttons

### DIFF
--- a/src/app/components/shared/card.tsx
+++ b/src/app/components/shared/card.tsx
@@ -129,14 +129,14 @@ export default function GlobalCard(props: GlobalCardSettings) {
         )}
         {props.button ? (
           <div className='self-auto'>
-            {props.buttonType != 'popover' ? (
-              <GlobalButton {...props.button} />
-            ) : (
+            {props.buttonType != 'button' ? (
               <GlobalPopover
                 button={props.button}
                 card={props}
                 body={props.body}
               />
+            ) : (
+              <GlobalButton {...props.button} />
             )}
           </div>
         ) : (

--- a/src/app/docs/(categories)/[category]/page.tsx
+++ b/src/app/docs/(categories)/[category]/page.tsx
@@ -77,6 +77,7 @@ export default async function Page(props: DynamicRoute) {
                 horizontalLine={true}
                 subheader={subPages[page].title}
                 longDescription={subPages[page].excerpt}
+                buttonType='button'
                 button={createButton(
                   join(props.params.category, page.replace('.mdx', ''))
                 )}

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -80,6 +80,7 @@ export default async function Page() {
                 iconId={subPages[page].icon}
                 subheader={subPages[page].title}
                 longDescription={subPages[page].excerpt}
+                buttonType='button'
                 button={createButton(join('/docs', page))}
               />
             </div>


### PR DESCRIPTION
In this PR I updated the ternary on the card to check if the status isn't button, this way we don't need to update every card component. Then I set the `buttonType` prop on the two card components used in the docs page so they're treated like buttons while all the other ones are treated like popovers.