### PR TITLE
canary update email address on form sub

### DIFF
--- a/src/app/components/form.tsx
+++ b/src/app/components/form.tsx
@@ -91,7 +91,7 @@ export default function ContactForm() {
       },
       sender: {
         name: 'John Hodge',
-        email: 'info@johnhodge.com',
+        email: 'no_reply@johnhodge.com',
       },
       previewText: `Hey ${data.firstName} I got your message and will follow up shortly.`,
       subject: `Thanks for reaching out, ${data.firstName}!`,

--- a/src/app/speaker-request/components/form.tsx
+++ b/src/app/speaker-request/components/form.tsx
@@ -125,7 +125,7 @@ export default function ContactForm() {
       },
       sender: {
         name: 'John Hodge',
-        email: 'info@johnhodge.com',
+        email: 'no_reply@johnhodge.com',
       },
       previewText: `Hey ${data.firstname} I got your request and will follow up shortly.`,
       subject: 'Speaker request recieved',


### PR DESCRIPTION
In this PR I changed the email used on submission notifications from info@ to no_reply@. 