### PR TITLE
[BUG] Inconsistent pre box shadow 

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -25,12 +25,6 @@ html {
   box-shadow: 0 0 0 0.075rem theme(colors.blue.400);
 }
 
-#doc_article > * > img,
-#doc_article > pre {
-  box-shadow: theme(boxShadow.lg);
-  border-radius: theme(borderRadius.md);
-}
-
 @media screen and (min-width: 2560px) {
   html {
     font-size: 28px;

--- a/src/app/resources/[documentation]/templates/doc.tsx
+++ b/src/app/resources/[documentation]/templates/doc.tsx
@@ -101,9 +101,7 @@ export default function Doc(props: DynamicTemplate) {
         route={props.route}
         rootDocTitle={rootDocTitle}
       />
-      <section
-        id='doc_article'
-        className='col-span-12 prose max-w-none prose-headings:font-black prose-a:decoration-dotted hover:prose-a:decoration-solid before:prose-code:hidden after:prose-code:hidden md:col-span-7'>
+      <section className='col-span-12 prose max-w-none prose-headings:font-black prose-a:decoration-dotted hover:prose-a:decoration-solid before:prose-code:hidden after:prose-code:hidden md:col-span-7 prose-pre:shadow-lg prose-pre:rounded-md prose-img:shadow-lg prose-img:rounded-md'>
         <h1>{data.title}</h1>
         <MDXRemote
           source={content}


### PR DESCRIPTION
This PR fixes an issue where the `pre` element's box shadow looked differently depending on how deeply nested it was. 

Originally the styles were applied using CSS to `pre` tags located at `#article_doc > pre`.

This meant that `pre` tags that were nested inside `ul` elements were not styled. 

To fix this, styles were applied to the `prose` identifier on the top-level `article` element so they would be cascaded to all `pre` tags in an article.