### PR TITLE
MAR-75 adjust scroll-mt on elements

### DIFF
--- a/src/app/resources/[documentation]/components/body.tsx
+++ b/src/app/resources/[documentation]/components/body.tsx
@@ -35,7 +35,7 @@ export function H3(props: Header) {
     .toLowerCase();
   return (
     <LinkedHeader href={`/${props.base}/#${headerAnchor}`}>
-      <h3 id={headerAnchor} className='scroll-mt-16'>
+      <h3 id={headerAnchor} className='scroll-mt-32'>
         {props.header}
       </h3>
     </LinkedHeader>
@@ -50,7 +50,7 @@ export function H2(props: Header) {
     .toLowerCase();
   return (
     <LinkedHeader href={`/${props.base}/#${headerAnchor}`}>
-      <h2 id={headerAnchor} className='scroll-mt-16'>
+      <h2 id={headerAnchor} className='scroll-mt-32'>
         {props.header}
       </h2>
     </LinkedHeader>

--- a/src/app/resources/[documentation]/components/toc.tsx
+++ b/src/app/resources/[documentation]/components/toc.tsx
@@ -21,7 +21,7 @@ export default function GlobalTOC(props: TOCData) {
   }
   return (
     <>
-      <div className='md:hidden sticky z-10 top-20'>
+      <div className='md:hidden sticky z-10 top-32'>
         <span
           onClick={handleClick}
           className='font-emoji rounded-lg min-w-fit inline-block px-1 text-3xl text-center border border-solid bg-gradient-to-b border-gray-400 from-gray-100 to-gray-50 text-gray-700'>

--- a/src/app/resources/[documentation]/templates/doc.tsx
+++ b/src/app/resources/[documentation]/templates/doc.tsx
@@ -139,7 +139,8 @@ export default function Doc(props: DynamicTemplate) {
       <aside className='hidden md:block col-span-3'>
         <div className='sticky top-32'>
           <p className='pb-4 text-xl font-black'>On this page</p>
-          <div className='max-h-[calc(75dvh-110px)] overflow-y-auto prose prose-headings:font-black'>
+          {/* the 81px is to make up for the height of the github section in the GlobalTOC */}
+          <div className='max-h-[calc((75dvh-110px)+81px)] overflow-y-auto prose prose-headings:font-black'>
             <MDXRemote
               source={content}
               components={{


### PR DESCRIPTION
In this PR, I adjusted the margin top scroll anchor to be 32, I also updated the `top` on the toc to be 32 as well. After doing this I noticed that with the columns at their current height, the TOC with the Github component would scroll up when the footer came into the viewport but the other one didn't (because it wasn't as tall). So, I adjusted its `max-h-` calculation to accommodate the height of the github component so the total height of the two sidebars was the same.