### PR TITLE
MAR-98 fix top spacing on mobile TOC icon

### DIFF
--- a/src/app/resources/[documentation]/components/toc.tsx
+++ b/src/app/resources/[documentation]/components/toc.tsx
@@ -21,7 +21,7 @@ export default function GlobalTOC(props: TOCData) {
   }
   return (
     <>
-      <div className='md:hidden sticky z-10 top-32'>
+      <div className='md:hidden sticky z-10 top-20'>
         <span
           onClick={handleClick}
           className='font-emoji rounded-lg min-w-fit inline-block px-1 text-3xl text-center border border-solid bg-gradient-to-b border-gray-400 from-gray-100 to-gray-50 text-gray-700'>


### PR DESCRIPTION
In this PR, the `top-32` class was replaced with the `top-20` to fix a bug where the TOC icon was showing up lower than expected on mobile.