### PR TITLE
MAR-100 fix broken gh link

### DIFF
--- a/src/app/resources/[documentation]/components/github.tsx
+++ b/src/app/resources/[documentation]/components/github.tsx
@@ -11,8 +11,8 @@ export default function GitHubData(props: PostFileData) {
         className='py-2 flex items-center gap-1'
         target='_blank'
         href={`https://github.com/johnhodge/johnhodge/blob/canary/${props.file.MDXFilePath.replace(
-          /.*\/documentation\//,
-          'documentation/'
+          /.*\/resources\//,
+          'resources/'
         )}`}>
         <svg
           className='inline-block'


### PR DESCRIPTION
In this PR I fixed the broken gh link.

This is a quick fix and is based on changing the hard code of the directory name from 'documentation' to 'resources'. We might want to consider this a quick that I'll push to prod, and then we can make a more comprehensive solution that pulls the directory name to be used in the regex from the props.