### PR TITLE
MAR-100 fix broken gh link (#150)

### DIFF
--- a/src/app/resources/[documentation]/components/github.tsx
+++ b/src/app/resources/[documentation]/components/github.tsx
@@ -11,8 +11,8 @@ export default function GitHubData(props: PostFileData) {
         className='py-2 flex items-center gap-1'
         target='_blank'
         href={`https://github.com/johnhodge/johnhodge/blob/canary/${props.file.MDXFilePath.replace(
-          /.*\/documentation\//,
-          'documentation/'
+          /.*\/resources\//,
+          'resources/'
         )}`}>
         <svg
           className='inline-block'


### PR DESCRIPTION
In this PR I fixed the broken gh link in the docs sidebar. I'm going to leave the other branches open to work on a more comprehensive solution while this is pushed to prod.