### PR TITLE
Mar 100 broken gh link

### DIFF
--- a/src/app/resources/[documentation]/components/github.tsx
+++ b/src/app/resources/[documentation]/components/github.tsx
@@ -11,8 +11,8 @@ export default function GitHubData(props: PostFileData) {
         className='py-2 flex items-center gap-1'
         target='_blank'
         href={`https://github.com/johnhodge/johnhodge/blob/canary/${props.file.MDXFilePath.replace(
-          /.*\/resources\//,
-          'resources/'
+          new RegExp('/.*/' + props.file.rootDirectory + '/'),
+          `${props.file.rootDirectory}/`
         )}`}>
         <svg
           className='inline-block'

--- a/src/app/resources/[documentation]/components/github.tsx
+++ b/src/app/resources/[documentation]/components/github.tsx
@@ -11,8 +11,8 @@ export default function GitHubData(props: PostFileData) {
         className='py-2 flex items-center gap-1'
         target='_blank'
         href={`https://github.com/johnhodge/johnhodge/blob/canary/${props.file.MDXFilePath.replace(
-          /.*\/documentation\//,
-          'documentation/'
+          /.*\/resources\//,
+          'resources/'
         )}`}>
         <svg
           className='inline-block'

--- a/src/utils/mdx.tsx
+++ b/src/utils/mdx.tsx
@@ -26,7 +26,10 @@ export function GetMdxData(fileLocation: string): PostData {
     excerpt: data.excerpt,
     icon: data.icon,
     date: data.date,
-    author: { firstName: data.firstName, lastName: data.lastName },
+    author: {
+      firstName: data.author.firstName,
+      lastName: data.author.lastName,
+    },
   };
 }
 


### PR DESCRIPTION
In this PR, I updated the regular expression in the github link to be more dynamic so if the `rootDirectory` changes, the link updates automatically.

While I was looking at this I also noticed an issue causing undefined errors on `GetMdxData` - it was simply looking in the wrong place for the author's name. I went ahead and updated the location of the author's data.