### PR TITLE
Fix misaligned linked header elements and improve wording

### DIFF
--- a/resources/case-studies/_index.mdx
+++ b/resources/case-studies/_index.mdx
@@ -24,6 +24,6 @@ Case studies follow the STAR structure (situation, task, action, result) and des
   type='note'
 />
 
-## Read the case studies!
+## Read my case studies!
 
 Read about projects I’ve led by clicking through the cards below.

--- a/resources/case-studies/strategic/_index.mdx
+++ b/resources/case-studies/strategic/_index.mdx
@@ -11,7 +11,7 @@ author:
 
 import GlobalCallout from '@/src/app/docs/components/callouts';
 
-## Welcome to the strategic case studies!
+## Welcome to my strategic case studies!
 
 In these documents, I'll discuss strategic initiatives I've led using fast rundowns that succinctly dive in on the details of the execution.
 

--- a/resources/case-studies/technical/_index.mdx
+++ b/resources/case-studies/technical/_index.mdx
@@ -11,7 +11,7 @@ author:
 
 import GlobalCallout from '@/src/app/docs/components/callouts';
 
-## Welcome to the technical case studies!
+## Welcome to my technical case studies!
 
 In these documents, I'll discuss technical projects that I've led using fast rundowns that succinctly dive in on the details of the implementation.
 

--- a/resources/case-studies/technical/app-store-data.mdx
+++ b/resources/case-studies/technical/app-store-data.mdx
@@ -31,8 +31,7 @@ This study discusses how we overcame inconsistent and outdated application data 
 />
 
 - **Bundle**: Application ID located in the RTB request at `app.bundle`.
-- **storeUrl**: Application page URL on the app store located in the RTB request at `app.storeurl` (I’m using camel case because I find it easier to read).
-- **Canonical store data**: The store data from the app store page.
+- **storeUrl**: Application page URL on the app store located in the RTB request at `app.storeurl` (I’ll use camel case throughout this study because I find it easier to read).
 - **Canonical bundle**: The bundle ID that appears on the final resolved page. This value comes from a variety of locations depending on the app store. In this document, I’ll use `154157` pulled from Roku via the `<meta name="appstore:bundle_id" content="154157">` tag.
 - **Canonical storeUrl**: The app store URL on the final resolved page (after any redirects if they exist). This is the URL in the `canonical` meta tag. In this document, I’ll use this URL as an example:
 
@@ -48,9 +47,9 @@ https://channelstore.roku.com/details/059720877140ff1005a7044cc02a4262/watch-tnt
 
 Some sellers represented their inventory for programmatic sales before the IAB spec was announced. For these sellers, changing the identifier used to represent their inventory can introduce a point of failure that could cost them a lot of money.
 
-Some sellers intentionally don’t use the canonical app store data because they don’t want buyers to cherry pick apps.
+Some sellers intentionally don’t use the canonical app store data because they don’t want buyers to cherry-pick apps.
 
-It’s unlikely these orgs will update their IDs to match the spec, so we need our product to accommodate variation data.
+It’s unlikely these organizations will update their IDs to match the spec, so we need our product to accommodate variation data.
 '
 type='success'
 />
@@ -63,7 +62,7 @@ This STAR analysis (situation, task, action, result) explains the product develo
 
 <GlobalCallout message='Give context about the problem' type='note' />
 
-Our system looks for `bundle`'s in the incoming request, that bundle is mapped to a publisher, and the publisher is targeted in the front-end. If a bundle is not mapped to a publisher, that inventory cannot be activated against.
+Our system looks for `bundle`'s in the incoming request, that bundle is mapped to a publisher, and the publisher is targeted in the front end. If a bundle is not mapped to a publisher, that inventory cannot be activated against.
 
 ---
 
@@ -73,7 +72,7 @@ Incoming data can appear differently from different publishers and sellers.
 - Some sellers include malformed `bundle`’s either from legacy sales pipelines or on accident. A lot of this data is set manually in an ad server by a person, sometimes they’re just copying and pasting from a spreadsheet, so there’s plenty of room for accidents.
 - It’s common for a `bundle` to have requests with multiple different `storeUrl`'s on accident (malformed `storeUrl`).
 
-This lack of data integrity makes it hard to scale how we access inventory since associating a canonical `bundle` and a publisher could miss many malformed `bundle`'s. Likewise, fully manual associations between a malformed `bundle` to a publisher can be labor intensive and error prone.
+This lack of data integrity makes it hard to scale how we access inventory since associating a canonical `bundle` and a publisher could miss many malformed `bundle`'s. Likewise, fully manual associations between a malformed `bundle` to a publisher can be labor-intensive and error-prone.
 
 ---
 
@@ -83,7 +82,7 @@ For example, if we see that requests for `bundle` `154157` can contain several d
 
 ---
 
-As one more added complexity, if these associations have platform-wide impacts, any changes would be realized across the entire system (in the front-end, over API reports feeds, and in decisioning engines). Sensitivities like this, coupled with the fragile nature of data integrity, makes it nearly impossible to fully automate a solution safely. Some user intervention is required, but too much can make it preventatively difficult to create mappings quickly.
+As one more added complexity, these associations have platform-wide impacts, any changes would be realized across the entire system (in the front-end, over API report feeds, and in decisioning engines). Sensitivities like this, coupled with the fragile nature of data integrity, make it nearly impossible to fully automate a solution safely. Some user intervention is required, but too much can make it preventatively difficult to create mappings quickly.
 
 ### Task
 
@@ -97,7 +96,7 @@ As one more added complexity, if these associations have platform-wide impacts, 
 <GlobalCallout
   message='
 **Fun fact**
-I built this POC in Python, persisted the data in a text file, and submitted a PR to the corporate GitHub account (it’s probably still there) that explained how it works and shared supporting confluence docs. Engineering leadership reviewed it and in turn paired me with some dedicated engineers to build the full version in Go.
+I built this POC in Python, persisted the data in a text file, submitted a PR to the corporate GitHub account, and shared supporting confluence docs and diagrams explaining how it works. Engineering leadership reviewed it and in turn, paired me with some dedicated engineers to build the full version in Go.
 '
   type='success'
 />
@@ -133,7 +132,7 @@ This diagram is *extremely* simplified for brevity and to comply with confidenti
 
   - For Roku, we needed to accommodate some interesting behavior.
 
-    - Being as they use React with client-side hydration, we had to pause our crawler until certain page elements were in view.
+    - Being that they use React with client-side hydration, we had to pause our crawler until certain page elements were in view.
     - In the bid requests, it was common for us to receive a `storeUrl` like this:
 
     ```
@@ -142,24 +141,24 @@ This diagram is *extremely* simplified for brevity and to comply with confidenti
 
     (`154157` is the `bundle` ID for the Watch TNT app)
 
-    The Roku servers would redirect this page to the canonical url:
+    The Roku servers would redirect this page to the canonical URL:
 
     ```
     https://channelstore.roku.com/details/059720877140ff1005a7044cc02a4262/watch-tnt
     ```
 
-    - It was very common for this redirect to fail and send our crawler to the wrong page. To combat this, we decided to not accept the first page our crawler resolved, and instead kept placing calls until we got 3 consecutive identical values in the `canonical` meta tag. We had thresholds for errors so we wouldn’t keep hitting a URL indefinitely.
+    - It was very common for this redirect to fail and send our crawler to the wrong page. To combat this, we decided to not accept the first page our crawler resolved and instead kept placing calls until we got 3 consecutive identical values in the `canonical` meta tag. We had thresholds for errors so we wouldn’t keep hitting a URL indefinitely.
 
-- If/when the page resolved we would push raw crawled data to a table of logs.
+- If/when the page is resolved we will push raw crawled data to a table of logs.
 - We would check if the resolved URL was the same as the one in the request. If it was, then we would label the one in the request as the canonical URL. If it wasn’t, then we would associate it as a variation of the canonical. Remember, the URL in the request resolved to this page 3 consecutive times. The app store itself is saying that they expect the URL in the request to represent this final URL, so we felt confident calling this the canonical URL.
-- We would then check if the `bundle` was the same as the one in the request. If it was, then we would label it is as the canonical `bundle` and if it wasn’t, then we would associate it as a variation of the canonical.
+- We would then check if the `bundle` was the same as the one in the request. If it was, then we would label it as the canonical `bundle` and if it wasn’t, then we would associate it as a variation of the canonical.
 - In addition to the canonical and variation data associations, we also pulled down other information about the apps like name, developer URL, description, rating, logos, downloads, genre, and any other data available.
-- This system ran asynchronously alongside the bidder and the rest of the platform. App store data doesn’t change that often, so we didn’t hit every URL that came through (we saw about 5-10M QPS). Instead, we applied a sample and limited calls if a URL already exists in our system. This way we could keep our app store data up-to-date without incurring high processing fees. Running our program parallel to our bidder kept our program out of the way of bidder functions that need to run in single digit milliseconds. This is the main reason we were able to run consecutive calls to the same URL (for Roku - described above) without having to worry about processing times.
+- This system ran asynchronously alongside the bidder and the rest of the platform. App store data doesn’t change that often, so we didn’t hit every URL that came through (we saw about 5-10M QPS). Instead, we applied a sample and limited calls if a URL already existed in our system. This way we could keep our app store data up-to-date without incurring high processing costs. Running our program parallel to our bidder kept our program out of the way of time-sensitive bidding activities that need to run in single-digit milliseconds. This is the main reason we were able to run consecutive calls to the same URL (for Roku - described above) without having to worry about processing times.
 
 #### Use canonical data and variation data in dashboards
 
 - By this point, the hard part was mostly over.
-- Now that we have canonical `bundle` and `storeUrl` values and their variations in a database, we need to raise that data up to the user.
+- Now that we have canonical `bundle` and `storeUrl` values and their variations in a database, we need to raise that data to the user.
 - Our data set was stored in BigQuery. This system would duplicate rows and didn’t create nested arrays for variations. In other words, the output of two crawl jobs for the same page with different variation values might be represented like this:
 
 ```

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,7 +20,9 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang='en' className='antialiased'>
+    <html
+      lang='en'
+      className={`${inter.variable} ${firaCode.variable} antialiased`}>
       <Script id='google-tag-manager' strategy='afterInteractive'>
         {`(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -28,7 +30,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','GTM-P34JZK')`}
       </Script>
-      <body className={`${inter.variable} ${firaCode.variable}`}>
+      <body>
         <noscript
           dangerouslySetInnerHTML={{
             __html: `<iframe

--- a/src/app/resources/[category]/components/body.tsx
+++ b/src/app/resources/[category]/components/body.tsx
@@ -18,8 +18,8 @@ type LinkedHeaderProps = {
 
 export default function LinkedHeader(props: LinkedHeaderProps) {
   return (
-    <Link href={props.href} className='relative group no-underline'>
-      <span className='hidden absolute -left-4 font-black text-lg z-0 group-hover:md:block'>
+    <Link href={props.href} className='relative font-black group no-underline'>
+      <span className='hidden absolute margin-auto -left-4 text-lg z-0 group-hover:md:block'>
         ⌗
       </span>
       {props.children}
@@ -34,11 +34,11 @@ export function H3(props: Header) {
     .replaceAll('.', '')
     .toLowerCase();
   return (
-    <LinkedHeader href={`/${props.base}/#${headerAnchor}`}>
-      <h3 id={headerAnchor} className='scroll-mt-32'>
+    <h3 id={headerAnchor} className='scroll-mt-32'>
+      <LinkedHeader href={`/${props.base}/#${headerAnchor}`}>
         {props.header}
-      </h3>
-    </LinkedHeader>
+      </LinkedHeader>
+    </h3>
   );
 }
 
@@ -49,11 +49,11 @@ export function H2(props: Header) {
     .replaceAll('.', '')
     .toLowerCase();
   return (
-    <LinkedHeader href={`/${props.base}/#${headerAnchor}`}>
-      <h2 id={headerAnchor} className='scroll-mt-32'>
+    <h2 id={headerAnchor} className='scroll-mt-32'>
+      <LinkedHeader href={`/${props.base}/#${headerAnchor}`}>
         {props.header}
-      </h2>
-    </LinkedHeader>
+      </LinkedHeader>
+    </h2>
   );
 }
 

--- a/src/app/speaker-request/page.tsx
+++ b/src/app/speaker-request/page.tsx
@@ -6,7 +6,7 @@ import { Metadata } from 'next';
 
 export const metadata: Metadata = GetMetadata({
   pageName: 'Speaker request',
-  description: 'Book John as a speaker at your next event.',
+  description: 'Book me as a speaker at your next event.',
   path: 'speaker-request',
   index: true,
   follow: true,
@@ -18,7 +18,7 @@ export default async function SpeakerRequest() {
     <Article
       id='request'
       headline='Speaker request'
-      subhead='Let’s talk about it'>
+      subhead='Book me as a speaker at your next event'>
       <div className='grid grid-cols-6 gap-9 items-start'>
         <div className='col-span-6 md:col-span-4'>
           <ContactForm />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,6 +11,7 @@ module.exports = {
       fontFamily: {
         emoji: ['Apple Color Emoji'],
         mono: ['var(--firaCode)'],
+        sans: ['var(--inter)'],
       },
       spacing: {
         icon: '3rem',


### PR DESCRIPTION
In this PR, I fixed a bug that occurred when two headers were back to back in MDX that made the span containing `#` fall out of line with the rest of the header. I also adjusted some of the wording throughout the website and in some resource pages.